### PR TITLE
Add a fixer for django.conf.urls deprecations

### DIFF
--- a/src/django_upgrade/fixers/urls.py
+++ b/src/django_upgrade/fixers/urls.py
@@ -1,0 +1,61 @@
+"""
+Replace django.conf.urls with django.urls
+"""
+import ast
+from functools import partial
+from typing import Iterable, Tuple
+
+from tokenize_rt import Offset
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.tokens import find_and_replace_name, update_import_modules
+
+fixer = Fixer(
+    __name__,
+    min_version=(2, 2),
+)
+
+REWRITES = {
+    "django.conf.urls": {
+        "url": "django.urls",
+        "include": "django.urls",
+    },
+}
+MODULES = {
+    "django.conf.urls",
+    "django.urls",
+}
+NAME_MAP = {
+    "url": "re_path",
+}
+
+
+@fixer.register(ast.ImportFrom)
+def visit_ImportFrom(
+    state: State,
+    node: ast.ImportFrom,
+    parent: ast.AST,
+) -> Iterable[Tuple[Offset, TokenFunc]]:
+    if (
+        node.level == 0
+        and node.module in REWRITES
+        and any(alias.name in REWRITES[node.module] for alias in node.names)
+    ):
+        yield ast_start_offset(node), partial(
+            update_import_modules, node=node, module_rewrites=REWRITES[node.module]
+        )
+
+
+@fixer.register(ast.Name)
+def visit_Name(
+    state: State,
+    node: ast.Name,
+    parent: ast.AST,
+) -> Iterable[Tuple[Offset, TokenFunc]]:
+    if (name := node.id) in NAME_MAP and any(
+        name in state.from_imports[m] for m in MODULES
+    ):
+        yield ast_start_offset(node), partial(
+            find_and_replace_name, name=name, new=NAME_MAP[name]
+        )

--- a/tests/fixers/test_urls.py
+++ b/tests/fixers/test_urls.py
@@ -1,0 +1,41 @@
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(2, 2))
+
+
+def test_include_import():
+    check_transformed(
+        """\
+        from django.conf.urls import include
+        """,
+        """\
+        from django.urls import include
+        """,
+        settings,
+    )
+
+
+def test_url_import():
+    check_transformed(
+        """\
+        from django.conf.urls import url
+        """,
+        """\
+        from django.urls import re_path
+        """,
+        settings,
+    )
+
+
+def test_additional_i18n_patterns_import():
+    check_transformed(
+        """\
+        from django.conf.urls import include, i18n_patterns
+        """,
+        """\
+        from django.urls import include
+        from django.conf.urls import i18n_patterns
+        """,
+        settings,
+    )


### PR DESCRIPTION
This fixer doesn't work yet. It somehow doesn't replace `django.conf.urls.url` with `django.urls.re_path`, only with `django.urls.url`.

That's a bit sad. I'm still posting it here. This fixer would make my life so much easier. Thanks :)