### PR TITLE
Improve Flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,5 @@ source =
 show_missing = True
 
 [flake8]
-max-line-length = 80
-select = E,F,W,B,B950,C,I,TYP
-ignore = E203,E501,W503
+max-line-length = 88
+extend-ignore = E203

--- a/src/django_upgrade/fixers/password_reset_timeout_days.py
+++ b/src/django_upgrade/fixers/password_reset_timeout_days.py
@@ -1,6 +1,6 @@
 """
 Replace imports from django.utils.encoding:
-https://docs.djangoproject.com/en/3.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text  # noqa: B950
+https://docs.djangoproject.com/en/3.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text  # noqa: E501
 """
 import ast
 import re

--- a/src/django_upgrade/fixers/utils_encoding.py
+++ b/src/django_upgrade/fixers/utils_encoding.py
@@ -1,6 +1,6 @@
 """
 Replace imports from django.utils.encoding:
-https://docs.djangoproject.com/en/3.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text  # noqa: B950
+https://docs.djangoproject.com/en/3.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text  # noqa: E501
 """
 import ast
 from functools import partial


### PR DESCRIPTION
Use only Black compat options. Removing 'select' declaration means that plugin error codes are selected by default.
