### PR TITLE
Make JSONField and NullBooleanField fixers ignore migration files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,11 @@ History
 
   Thanks to qdufrois for the report in `Issue #121 <https://github.com/adamchainz/django-upgrade/issues/121>`__.
 
+* Made ``JSONField`` and ``NullBooleanField`` fixers ignore migrations files.
+  Django kept these old field classes around for use in historical migrations, so there’s no need to rewrite such cases.
+
+  Thanks to Matthieu Rigal and Bruno Alla for the report in `Issue #79 <https://github.com/adamchainz/django-upgrade/issues/79>`__.
+
 1.4.0 (2021-10-23)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -342,6 +342,8 @@ Django 3.1
 ~~~~~~~~~~~~~
 
 Rewrites imports of ``JSONField`` and related transform classes from those in ``django.contrib.postgres`` to the new all-database versions.
+Ignores usage in migration files, since Django kept the old class around to support old migrations.
+You will need to make migrations after this fix makes changes to models.
 
 .. code-block:: diff
 
@@ -387,6 +389,8 @@ Injects the now-required ``length`` argument, with its previous default ``12``.
 ~~~~~~~~~~~~~~~~~~~~
 
 Transforms the ``NullBooleanField()`` model field to ``BooleanField(null=True)``.
+Ignores usage in migration files, since Django kept the old class around to support old migrations.
+You will need to make migrations after this fix makes changes to models.
 
 .. code-block:: diff
 

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import ast
+import os
 import pkgutil
+import re
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Tuple, TypeVar
 
@@ -15,6 +17,11 @@ class Settings:
         self.target_version = target_version
 
 
+settings_re = re.compile(r"\bsettings\b")
+
+test_re = re.compile(r"(\b|_)tests?(\b|_)")
+
+
 class State:
     def __init__(
         self,
@@ -25,6 +32,15 @@ class State:
         self.settings = settings
         self.filename = filename
         self.from_imports = from_imports
+
+    def looks_like_migrations_file(self) -> bool:
+        return "migrations" in self.filename.split(os.path.sep)
+
+    def looks_like_settings_file(self) -> bool:
+        return settings_re.search(self.filename) is not None
+
+    def looks_like_test_file(self) -> bool:
+        return test_re.search(self.filename) is not None
 
 
 AST_T = TypeVar("AST_T", bound=ast.AST)

--- a/src/django_upgrade/fixers/jsonfield.py
+++ b/src/django_upgrade/fixers/jsonfield.py
@@ -47,6 +47,7 @@ def visit_ImportFrom(
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
         node.module in REWRITES
+        and not state.looks_like_migrations_file()
         and is_rewritable_import_from(node)
         and any(alias.name in REWRITES[node.module] for alias in node.names)
     ):

--- a/src/django_upgrade/fixers/password_reset_timeout_days.py
+++ b/src/django_upgrade/fixers/password_reset_timeout_days.py
@@ -5,7 +5,6 @@ https://docs.djangoproject.com/en/3.0/releases/3.0/#django-utils-encoding-force-
 from __future__ import annotations
 
 import ast
-import re
 from functools import partial
 from typing import Iterable
 
@@ -23,12 +22,6 @@ fixer = Fixer(
 OLD_NAME = "PASSWORD_RESET_TIMEOUT_DAYS"
 NEW_NAME = "PASSWORD_RESET_TIMEOUT"
 
-settings_re = re.compile(r"\bsettings\b")
-
-
-def looks_like_settings_file(filename: str) -> bool:
-    return settings_re.search(filename) is not None
-
 
 @fixer.register(ast.Assign)
 def visit_Assign(
@@ -40,7 +33,7 @@ def visit_Assign(
         len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
         and node.targets[0].id == OLD_NAME
-        and looks_like_settings_file(state.filename)
+        and state.looks_like_settings_file()
     ):
         yield ast_start_offset(node), partial(rewrite_setting, node=node)
 

--- a/src/django_upgrade/fixers/testcase_databases.py
+++ b/src/django_upgrade/fixers/testcase_databases.py
@@ -5,7 +5,6 @@ https://docs.djangoproject.com/en/2.2/releases/2.2/#features-deprecated-in-2-2
 from __future__ import annotations
 
 import ast
-import re
 from functools import partial
 from typing import Iterable
 
@@ -21,13 +20,6 @@ fixer = Fixer(
 )
 
 
-test_re = re.compile(r"(\b|_)tests?(\b|_)")
-
-
-def looks_like_test_file(filename: str) -> bool:
-    return test_re.search(filename) is not None
-
-
 @fixer.register(ast.Assign)
 def visit_Assign(
     state: State,
@@ -41,7 +33,7 @@ def visit_Assign(
         and node.targets[0].id in ("allow_database_queries", "multi_db")
         and isinstance(node.value, ast.Constant)
         and (node.value.value is True or node.value.value is False)
-        and looks_like_test_file(state.filename)
+        and state.looks_like_test_file()
     ):
         yield ast_start_offset(node), partial(
             replace_assignment, node=node, value=node.value.value

--- a/tests/fixers/test_jsonfield.py
+++ b/tests/fixers/test_jsonfield.py
@@ -26,6 +26,18 @@ def test_unrecognized_import_format():
     )
 
 
+def test_untransformed_in_migration_file():
+    check_noop(
+        """\
+        from django.contrib.postgres.fields import (
+            JSONField, KeyTransform,  KeyTextTransform,
+        )
+        """,
+        settings,
+        filename="example/core/migrations/0001_initial.py",
+    )
+
+
 def test_full():
     check_transformed(
         """\

--- a/tests/fixers/test_null_boolean_field.py
+++ b/tests/fixers/test_null_boolean_field.py
@@ -16,6 +16,17 @@ def test_unmatched_import():
     )
 
 
+def test_untransformed_in_migration_file():
+    check_noop(
+        """\
+        from django.db.models import NullBooleanField
+        field = NullBooleanField()
+        """,
+        settings,
+        filename="example/core/migrations/0001_initial.py",
+    )
+
+
 def test_transform_in_class():
     check_transformed(
         """\

--- a/tests/fixers/test_testcase_databases.py
+++ b/tests/fixers/test_testcase_databases.py
@@ -1,45 +1,9 @@
 from __future__ import annotations
 
-import pytest
-
 from django_upgrade.data import Settings
-from django_upgrade.fixers.testcase_databases import looks_like_test_file
 from tests.fixers.tools import check_noop, check_transformed
 
 settings = Settings(target_version=(2, 2))
-
-
-@pytest.mark.parametrize(
-    ("filename"),
-    (
-        "test_example.py",
-        "example_test.py",
-        "test.py",
-        "tests.py",
-        "myapp/test.py",
-        "myapp/tests.py",
-        "myapp/tests/base.py",
-        "myapp/tests/__init__.py",
-        "myapp/test_example.py",
-        "myapp/tests_example.py",
-        "myapp/example_test.py",
-        "myapp/example_tests.py",
-    ),
-)
-def test_looks_like_test_file_true(filename):
-    assert looks_like_test_file(filename)
-
-
-@pytest.mark.parametrize(
-    ("filename"),
-    (
-        "conftest.py",
-        "protester.py",
-        "myapp/protests/models.py",
-    ),
-)
-def test_looks_like_test_file_false(filename):
-    assert not looks_like_test_file(filename)
 
 
 def test_not_test_file():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from django_upgrade.data import Settings, State
+
+
+@pytest.mark.parametrize(
+    ("filename"),
+    (
+        "test_example.py",
+        "example_test.py",
+        "test.py",
+        "tests.py",
+        "myapp/test.py",
+        "myapp/tests.py",
+        "myapp/tests/base.py",
+        "myapp/tests/__init__.py",
+        "myapp/test_example.py",
+        "myapp/tests_example.py",
+        "myapp/example_test.py",
+        "myapp/example_tests.py",
+    ),
+)
+def test_looks_like_test_file_true(filename):
+    state = State(
+        settings=Settings(target_version=(4, 0)),
+        filename=filename,
+        from_imports={},
+    )
+    assert state.looks_like_test_file()
+
+
+@pytest.mark.parametrize(
+    ("filename"),
+    (
+        "conftest.py",
+        "protester.py",
+        "myapp/protests/models.py",
+    ),
+)
+def test_looks_like_test_file_false(filename):
+    state = State(
+        settings=Settings(target_version=(4, 0)),
+        filename=filename,
+        from_imports={},
+    )
+    assert not state.looks_like_test_file()


### PR DESCRIPTION
Fixes #79.