### PR TITLE
Fix bug with default_app_config removal in nested __init__.py

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* Fix ``default_app_config`` fixer to work with ``__init__.py`` files in subdirectories.
+
+  Thanks to Bruno Alla in `PR #144 <https://github.com/adamchainz/django-upgrade/pull/144>`__.
+
 * Add ``--version`` flag.
 
   Thanks to Ferran Jovell in `PR #143 <https://github.com/adamchainz/django-upgrade/pull/143>`__.

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -21,7 +21,7 @@ settings_re = re.compile(r"\bsettings\b")
 
 test_re = re.compile(r"(\b|_)tests?(\b|_)")
 
-dunder_init_re = re.compile(r"(^|[\/])__init__.py$")
+dunder_init_re = re.compile(r"(^|[\\/])__init__\.py$")
 
 
 class State:

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -21,7 +21,7 @@ settings_re = re.compile(r"\bsettings\b")
 
 test_re = re.compile(r"(\b|_)tests?(\b|_)")
 
-dunder_init_re = re.compile(r"\b__init__\.py$")
+dunder_init_re = re.compile(r"\b__init__.py$")
 
 
 class State:

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -21,7 +21,7 @@ settings_re = re.compile(r"\bsettings\b")
 
 test_re = re.compile(r"(\b|_)tests?(\b|_)")
 
-dunder_init_re = re.compile(r"\b__init__.py$")
+dunder_init_re = re.compile(r"(^|[\/])__init__.py$")
 
 
 class State:

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -21,6 +21,8 @@ settings_re = re.compile(r"\bsettings\b")
 
 test_re = re.compile(r"(\b|_)tests?(\b|_)")
 
+dunder_init_re = re.compile(r"\b__init__\.py$")
+
 
 class State:
     def __init__(
@@ -41,6 +43,9 @@ class State:
 
     def looks_like_test_file(self) -> bool:
         return test_re.search(self.filename) is not None
+
+    def looks_like_dunder_init_file(self) -> bool:
+        return dunder_init_re.search(self.filename) is not None
 
 
 AST_T = TypeVar("AST_T", bound=ast.AST)

--- a/src/django_upgrade/fixers/default_app_config.py
+++ b/src/django_upgrade/fixers/default_app_config.py
@@ -27,7 +27,7 @@ def visit_Assign(
     parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.filename == "__init__.py"
+        state.looks_like_dunder_init_file()
         and isinstance(parent, ast.Module)
         and len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)

--- a/tests/fixers/test_default_app_config.py
+++ b/tests/fixers/test_default_app_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from django_upgrade.data import Settings
 from tests.fixers.tools import check_noop, check_transformed
 
@@ -47,24 +49,28 @@ def test_dynamic():
     )
 
 
-def test_invalid_filename():
+@pytest.mark.parametrize("filename", ["my_app.py", "my_app__init__.py"])
+def test_invalid_filename(filename):
     check_noop(
         """\
         default_app_config = 'myapp.apps.MyAppConfig'
         """,
         settings,
-        filename="my_app.py",
+        filename=filename,
     )
 
 
-def test_simple_case():
+@pytest.mark.parametrize(
+    "filename", ["__init__.py", "app/__init__.py", "project/app/__init__.py"]
+)
+def test_simple_case(filename):
     check_transformed(
         """\
         default_app_config = 'myapp.apps.MyAppConfig'
         """,
         "",
         settings,
-        filename="__init__.py",
+        filename=filename,
     )
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -58,7 +58,7 @@ def test_looks_like_test_file_false(filename):
         r"project\package\__init__.py",
     ),
 )
-def looks_like_dunder_init_file_true(filename):
+def test_looks_like_dunder_init_file_true(filename):
     state = State(
         settings=Settings(target_version=(4, 0)),
         filename=filename,
@@ -78,7 +78,7 @@ def looks_like_dunder_init_file_true(filename):
         "init__.py",
     ),
 )
-def looks_like_dunder_init_file_false(filename):
+def test_looks_like_dunder_init_file_false(filename):
     state = State(
         settings=Settings(target_version=(4, 0)),
         filename=filename,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -64,7 +64,7 @@ def test_looks_like_dunder_init_file_true(filename):
         filename=filename,
         from_imports={},
     )
-    assert state.looks_like_test_file()
+    assert state.looks_like_dunder_init_file()
 
 
 @pytest.mark.parametrize(
@@ -84,4 +84,4 @@ def test_looks_like_dunder_init_file_false(filename):
         filename=filename,
         from_imports={},
     )
-    assert not state.looks_like_test_file()
+    assert not state.looks_like_dunder_init_file()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -46,3 +46,39 @@ def test_looks_like_test_file_false(filename):
         from_imports={},
     )
     assert not state.looks_like_test_file()
+
+
+@pytest.mark.parametrize(
+    ("filename"),
+    (
+        "__init__.py",
+        "package/__init__.py",
+        "project/package/__init__.py",
+    ),
+)
+def looks_like_dunder_init_file_true(filename):
+    state = State(
+        settings=Settings(target_version=(4, 0)),
+        filename=filename,
+        from_imports={},
+    )
+    assert state.looks_like_test_file()
+
+
+@pytest.mark.parametrize(
+    ("filename"),
+    (
+        "__thing__init__.py",
+        "__init___py",
+        "_init_.py",
+        "__init.py",
+        "init__.py",
+    ),
+)
+def looks_like_dunder_init_file_false(filename):
+    state = State(
+        settings=Settings(target_version=(4, 0)),
+        filename=filename,
+        from_imports={},
+    )
+    assert not state.looks_like_test_file()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -53,7 +53,9 @@ def test_looks_like_test_file_false(filename):
     (
         "__init__.py",
         "package/__init__.py",
+        "package\__init__.py",
         "project/package/__init__.py",
+        "project\package\__init__.py",
     ),
 )
 def looks_like_dunder_init_file_true(filename):
@@ -69,6 +71,7 @@ def looks_like_dunder_init_file_true(filename):
     ("filename"),
     (
         "__thing__init__.py",
+        "thing-__init__.py",
         "__init___py",
         "_init_.py",
         "__init.py",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -53,9 +53,9 @@ def test_looks_like_test_file_false(filename):
     (
         "__init__.py",
         "package/__init__.py",
-        "package\__init__.py",
+        r"package\__init__.py",
         "project/package/__init__.py",
-        "project\package\__init__.py",
+        r"project\package\__init__.py",
     ),
 )
 def looks_like_dunder_init_file_true(filename):


### PR DESCRIPTION
The current version of `default_app_config` removal implemented in #140 only works if the `__init__.py` is at the top level, not if it's under a subdirectory, which is where it's going to be most of the time.