### PR TITLE
Update `from_imports` type hint to use `DefaultDict`

### DIFF
--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -5,7 +5,16 @@ import os
 import pkgutil
 import re
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Tuple, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    DefaultDict,
+    Iterable,
+    List,
+    Tuple,
+    TypeVar,
+)
 
 from tokenize_rt import Offset, Token
 
@@ -29,7 +38,7 @@ class State:
         self,
         settings: Settings,
         filename: str,
-        from_imports: dict[str, set[str]],
+        from_imports: DefaultDict[str, set[str]],
     ) -> None:
         self.settings = settings
         self.filename = filename

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 import pytest
 
 from django_upgrade.data import Settings, State
@@ -26,7 +28,7 @@ def test_looks_like_test_file_true(filename: str) -> None:
     state = State(
         settings=Settings(target_version=(4, 0)),
         filename=filename,
-        from_imports={},
+        from_imports=defaultdict(set),
     )
     assert state.looks_like_test_file()
 
@@ -43,7 +45,7 @@ def test_looks_like_test_file_false(filename: str) -> None:
     state = State(
         settings=Settings(target_version=(4, 0)),
         filename=filename,
-        from_imports={},
+        from_imports=defaultdict(set),
     )
     assert not state.looks_like_test_file()
 
@@ -62,7 +64,7 @@ def test_looks_like_dunder_init_file_true(filename: str) -> None:
     state = State(
         settings=Settings(target_version=(4, 0)),
         filename=filename,
-        from_imports={},
+        from_imports=defaultdict(set),
     )
     assert state.looks_like_dunder_init_file()
 
@@ -82,6 +84,6 @@ def test_looks_like_dunder_init_file_false(filename: str) -> None:
     state = State(
         settings=Settings(target_version=(4, 0)),
         filename=filename,
-        from_imports={},
+        from_imports=defaultdict(set),
     )
     assert not state.looks_like_dunder_init_file()


### PR DESCRIPTION
Following https://github.com/adamchainz/django-upgrade/pull/167#discussion_r954820379, I think this fixes the typing issue while keeping the more accurate type annotation.