### PR TITLE
Rewrite `admin.site.register()` calls to `@admin.register()`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* Add Django 1.7+ fixer to rewrite ``admin.site.register()`` calls into ``@admin.register()`` when eligible.
+
+  Thanks to Thibaut Decombe in `PR #189 <https://github.com/adamchainz/django-upgrade/pull/189>`__.
+
 1.10.0 (2022-09-07)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -127,27 +127,27 @@ A single ``else`` block may be present, but ``elif`` is not supported.
 See also `pyupgrade’s similar feature <https://github.com/asottile/pyupgrade/#python2-and-old-python3x-blocks>`__ that removes outdated code from checks on the Python version.
 
 Django 1.7
------------
+----------
 
-`Release Notes <https://docs.djangoproject.com/en/dev/releases/1.7/>`__
+`Release Notes <https://docs.djangoproject.com/en/stable/releases/1.7/>`__
 
 Admin model registration
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Rewrites ``admin.site.register()`` calls to the new ``@admin.register()`` decorator syntax when eligible.
 
 .. code-block:: diff
 
     +@admin.register(MyModel)
-    class MyCustomAdmin:
-        pass
+     class MyCustomAdmin:
+         pass
 
     -admin.site.register(MyModel, MyCustomAdmin)
 
 Django 1.9
 -----------
 
-`Release Notes <https://docs.djangoproject.com/en/dev/releases/1.9/>`__
+`Release Notes <https://docs.djangoproject.com/en/stable/releases/1.9/>`__
 
 ``on_delete`` argument
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -126,10 +126,28 @@ A single ``else`` block may be present, but ``elif`` is not supported.
 
 See also `pyupgrade’s similar feature <https://github.com/asottile/pyupgrade/#python2-and-old-python3x-blocks>`__ that removes outdated code from checks on the Python version.
 
+Django 1.7
+-----------
+
+`Release Notes <https://docs.djangoproject.com/en/dev/releases/1.7/>`__
+
+Admin model registration
+~~~~~~~~~~~~~~~~~~~~~~
+
+Rewrites ``admin.site.register()`` calls to the new ``@admin.register()`` decorator syntax when eligible.
+
+.. code-block:: diff
+
+    +@admin.register(MyModel)
+    class MyCustomAdmin:
+        pass
+
+    -admin.site.register(MyModel, MyCustomAdmin)
+
 Django 1.9
 -----------
 
-`Release Notes <https://github.com/django/django/blob/main/docs/releases/1.9.txt>`__
+`Release Notes <https://docs.djangoproject.com/en/dev/releases/1.9/>`__
 
 ``on_delete`` argument
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -44,13 +44,13 @@ def visit_ClassDef(
 def update_class_def(
     tokens: list[Token], i: int, *, node: ast.ClassDef, state: State
 ) -> None:
-    arg_kwargs = class_to_decorate.get(state, {}).pop(node.name, set())
-    if len(arg_kwargs) == 1:
+    model_names = class_to_decorate.get(state, {}).pop(node.name, set())
+    if len(model_names) == 1:
         j, indent = extract_indent(tokens, i)
         insert(
             tokens,
             j,
-            new_src=f"{indent}@admin.register({arg_kwargs.pop()})\n",
+            new_src=f"{indent}@admin.register({model_names.pop()})\n",
         )
 
 
@@ -76,7 +76,7 @@ def visit_Call(
         )
     ):
         admin_model_name = node.args[1].id
-        if admin_model_name in class_to_decorate.get(state, {}).keys():
+        if admin_model_name in class_to_decorate.get(state, {}):
             class_to_decorate[state][admin_model_name].add(node.args[0].id)
             yield ast_start_offset(node), partial(
                 erase_register_node,
@@ -104,6 +104,6 @@ def visit_Call(
 def erase_register_node(
     tokens: list[Token], i: int, *, node: ast.Call, admin_model_name: str, state: State
 ) -> None:
-    arg_kwargs = class_to_decorate.get(state, {}).get(admin_model_name, set())
-    if len(arg_kwargs) == 1:
+    model_names = class_to_decorate.get(state, {}).get(admin_model_name, set())
+    if len(model_names) == 1:
         erase_node(tokens, i, node=node)

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -40,7 +40,7 @@ def visit_ClassDef(
         class_to_decorate.setdefault(state, {})[node.name] = set()
         yield ast_start_offset(node), partial(
             update_class_def,
-            node=node,
+            name=node.name,
             state=state,
         )
 
@@ -71,10 +71,8 @@ def uses_full_super_in_init_or_new(node: ast.ClassDef) -> bool:
     return False
 
 
-def update_class_def(
-    tokens: list[Token], i: int, *, node: ast.ClassDef, state: State
-) -> None:
-    model_names = class_to_decorate.get(state, {}).pop(node.name, set())
+def update_class_def(tokens: list[Token], i: int, *, name: str, state: State) -> None:
+    model_names = class_to_decorate.get(state, {}).pop(name, set())
     if len(model_names) == 1:
         j, indent = extract_indent(tokens, i)
         insert(

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -1,6 +1,6 @@
 """
 Replace `admin.site.register` with the new `@register` decorator syntax:
-https://docs.djangoproject.com/en/dev/releases/1.7/#minor-features
+https://docs.djangoproject.com/en/stable/releases/1.7/#minor-features
 """
 from __future__ import annotations
 

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -103,20 +103,22 @@ def visit_Call(
             and isinstance(node.args[1], ast.Name)
         )
     ):
-        admin_model_name = node.args[1].id
-        if admin_model_name in class_to_decorate.get(state, {}):
-            class_to_decorate[state][admin_model_name].add(node.args[0].id)
+        admin_name = node.args[1].id
+        to_decorate = class_to_decorate.get(state, {})
+        if admin_name in to_decorate:
+            model_name = node.args[0].id
+            to_decorate[admin_name].add(model_name)
             yield ast_start_offset(node), partial(
                 erase_register_node,
                 node=parent,
-                admin_model_name=admin_model_name,
+                admin_name=admin_name,
                 state=state,
             )
 
 
 def erase_register_node(
-    tokens: list[Token], i: int, *, node: ast.Call, admin_model_name: str, state: State
+    tokens: list[Token], i: int, *, node: ast.Call, admin_name: str, state: State
 ) -> None:
-    model_names = class_to_decorate.get(state, {}).get(admin_model_name, set())
+    model_names = class_to_decorate.get(state, {}).get(admin_name, set())
     if len(model_names) == 1:
         erase_node(tokens, i, node=node)

--- a/src/django_upgrade/main.py
+++ b/src/django_upgrade/main.py
@@ -27,6 +27,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--target-version",
         default="2.2",
         choices=[
+            "1.7",
+            "1.8",
             "1.9",
             "1.10",
             "1.11",

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -88,6 +88,9 @@ def test_py2_style_init_super():
             def __init__(self, *args, **kwargs):
                 super(AuthorAdmin, self).__init__(*args, **kwargs)
 
+            def other(self):
+                pass
+
         admin.site.register(Author, AuthorAdmin)
         """,
         settings=settings,

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop, check_transformed
+
+settings = Settings(target_version=(1, 7))
+
+
+def test_no_custom_admin_class():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        admin.site.register(Author)
+        """,
+        settings,
+    )
+
+
+def test_kwargs_not_supported():
+    # To support this we would have to update the admin class definition
+    # by overriding attributes values. Django emulate that behaviour by
+    # constructing a subclass with these attributes.
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        class AuthorAdmin(admin.ModelAdmin):
+            pass
+        admin.site.register(Author, AuthorAdmin, save_as=True)
+        """,
+        settings,
+    )
+
+
+def test_imported_custom_admin():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+        from myapp.admin import AuthorAdmin
+
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        settings,
+    )
+
+
+def test_already_using_decorator_registration():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        @admin.register(Author)
+        class AuthorAdmin(admin.ModelAdmin):
+            pass
+        """,
+        settings,
+    )
+
+
+def test_multiple_model_one_admin():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.register(MyModel1, MyCustomAdmin)
+        admin.site.register(MyModel2, MyCustomAdmin)
+        """,
+        settings,
+    )
+
+
+def test_py2_style_init_super():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        class AuthorAdmin(admin.ModelAdmin):
+            def __init__(self, *args, **kwargs):
+                super(AuthorAdmin, self).__init__(*args, **kwargs)
+
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        settings=settings,
+    )
+
+
+def test_py2_style_init_super_with_inheritance():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        class AuthorAdmin(CustomMixin):
+            def __init__(self, *args, **kwargs):
+                super(CustomMixin, self).__init__(*args, **kwargs)
+
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        settings=settings,
+    )
+
+
+def test_py2_style_new_super():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        class AuthorAdmin(admin.ModelAdmin):
+            def __new__(cls, *args, **kwargs):
+                super(AuthorAdmin, self).__new__(cls, *args, **kwargs)
+
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        settings=settings,
+    )
+
+
+def test_simple_rewrite():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        class AuthorAdmin(admin.ModelAdmin):
+            pass
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        @admin.register(Author)
+        class AuthorAdmin(admin.ModelAdmin):
+            pass
+        """,
+        settings=settings,
+    )
+
+
+def test_multiple_rewrite():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author, Blog
+
+        class AuthorAdmin(admin.ModelAdmin):
+            pass
+
+        class BlogAdmin(admin.ModelAdmin):
+            pass
+
+        admin.site.register(Blog, BlogAdmin)
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import Author, Blog
+
+        @admin.register(Author)
+        class AuthorAdmin(admin.ModelAdmin):
+            pass
+
+        @admin.register(Blog)
+        class BlogAdmin(admin.ModelAdmin):
+            pass
+
+        """,
+        settings=settings,
+    )
+
+
+def test_custom_model_admin_base_class():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+        from myapp.admin import CustomModelAdmin
+
+        class AuthorAdmin(CustomModelAdmin):
+            pass
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+        from myapp.admin import CustomModelAdmin
+
+        @admin.register(Author)
+        class AuthorAdmin(CustomModelAdmin):
+            pass
+        """,
+        settings=settings,
+    )
+
+
+def test_complete():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author, Blog, MyModel1, MyModel2
+        from myapp.admin import MyImportedAdmin
+
+        class MyCustomAdmin:
+            pass
+
+        class AuthorAdmin(CustomModelAdmin):
+            pass
+
+        admin.site.register(MyModel1, MyCustomAdmin)
+        admin.site.register(MyModel2, MyCustomAdmin)
+        admin.site.register(Author, AuthorAdmin)
+        admin.site.register(Blog, MyImportedAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import Author, Blog, MyModel1, MyModel2
+        from myapp.admin import MyImportedAdmin
+
+        class MyCustomAdmin:
+            pass
+
+        @admin.register(Author)
+        class AuthorAdmin(CustomModelAdmin):
+            pass
+
+        admin.site.register(MyModel1, MyCustomAdmin)
+        admin.site.register(MyModel2, MyCustomAdmin)
+        admin.site.register(Blog, MyImportedAdmin)
+        """,
+        settings=settings,
+    )

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -110,6 +110,52 @@ def test_py2_style_init_super_with_inheritance():
     )
 
 
+def test_py2_style_init_super_with_branching():
+    check_transformed(
+        """\
+        import sys
+        from django.contrib import admin
+        from myapp.models import Ham, Spam
+
+        class HamAdmin(...):
+            pass
+
+        class SpamAdmin(SubAdmin):
+            def __init__(self, *args, **kwargs):
+                if sys.version_info >= (3, 10):
+                    # something
+                    super(SpamAdmin, self).__init__(*args, **kwargs)
+                else:
+                    # something else
+                    super(SubAdmin, self).__init__(*args, **kwargs)
+
+        admin.site.register(Ham, HamAdmin)
+        admin.site.register(Spam, SpamAdmin)
+        """,
+        """\
+        import sys
+        from django.contrib import admin
+        from myapp.models import Ham, Spam
+
+        @admin.register(Ham)
+        class HamAdmin(...):
+            pass
+
+        class SpamAdmin(SubAdmin):
+            def __init__(self, *args, **kwargs):
+                if sys.version_info >= (3, 10):
+                    # something
+                    super(SpamAdmin, self).__init__(*args, **kwargs)
+                else:
+                    # something else
+                    super(SubAdmin, self).__init__(*args, **kwargs)
+
+        admin.site.register(Spam, SpamAdmin)
+        """,
+        settings=settings,
+    )
+
+
 def test_py2_style_new_super():
     check_noop(
         """\

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -156,6 +156,32 @@ def test_py2_style_init_super_with_branching():
     )
 
 
+def test_py3_style_init_super():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        class AuthorAdmin(CustomMixin):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        @admin.register(Author)
+        class AuthorAdmin(CustomMixin):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+        """,
+        settings=settings,
+    )
+
+
 def test_py2_style_new_super():
     check_noop(
         """\

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -110,7 +110,41 @@ def test_py2_style_init_super_with_inheritance():
     )
 
 
-def test_py2_style_init_super_with_branching():
+def test_py2_style_init_super_with_outer_branching():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        class AuthorAdmin(CustomMixin):
+            if something():
+                def __init__(self, *args, **kwargs):
+                    super(CustomMixin, self).__init__(*args, **kwargs)
+
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        settings=settings,
+    )
+
+
+def test_py2_style_init_super_delayed():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        class AuthorAdmin(CustomMixin):
+            def __init__(self, *args, **kwargs):
+                sup = super(CustomMixin, self)
+                sup.__init__(*args, **kwargs)
+
+        admin.site.register(Author, AuthorAdmin)
+        """,
+        settings=settings,
+    )
+
+
+def test_py2_style_init_super_with_inner_branching():
     check_transformed(
         """\
         import sys


### PR DESCRIPTION
Implementation of the `admin.site.register` rewriter idea of #182 

The following methodology was used:
- `visit_ClassDef` to track custom admin candidates.
- `visit_Call` to find old style `__init__` / `__new__` methods. If any match, remove the last custom admin class candidate.
- `visit_Call` again to find exact `admin.site.register(MyModel, MyCustomAdmin)` match with `MyCustomAdmin` being one of the remaining candidates. Associated models are stored in a set so that if we have multiple match (`one-to-many` relation), we don't rewrite.

When backtracking, only remaining candidates are rewritten.