### PR TITLE
Fix indent extraction to also consider UNIMPORTANT_WS

### DIFF
--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -81,7 +81,7 @@ def extract_indent(tokens: list[Token], i: int) -> tuple[int, str]:
     indentation string. Otherwise return the current position and "".
     """
     j = i
-    if j > 0 and tokens[j - 1].name == INDENT:
+    if j > 0 and tokens[j - 1].name in (INDENT, UNIMPORTANT_WS):
         j -= 1
         indent = tokens[j].src
     else:

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -257,6 +257,30 @@ def test_simple_rewrite():
     )
 
 
+def test_simple_rewrite_indented():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        if True:
+            class AuthorAdmin(admin.ModelAdmin):
+                pass
+            admin.site.register(Author, AuthorAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import Author
+
+        if True:
+            @admin.register(Author)
+            class AuthorAdmin(admin.ModelAdmin):
+                pass
+        """,
+        settings=settings,
+    )
+
+
 def test_multiple_rewrite():
     check_transformed(
         """\


### PR DESCRIPTION
tokenize only adds INDENT and DEDENT tokens at the start and end of indented blocks, which makes it real hard to track back to find indentation. tokenize-rt helps by adding UNIMPORTANT_WS tokens to the start of every indented line. `extract_indent()` was previously ignoring these, so it didn't extract the actual indent except in the first line of each block. This didn't cause a problem in most cases, since we're often deleting and reinserting on the same line, but where we are only deleting, it would lead to indenting spaces being left around.