### PR TITLE
Support multiple model classes in @admin.register fixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,11 +138,14 @@ Rewrites ``admin.site.register()`` calls to the new ``@admin.register()`` decora
 
 .. code-block:: diff
 
-    +@admin.register(MyModel)
-     class MyCustomAdmin:
-         pass
+     from django.contrib import admin
 
-    -admin.site.register(MyModel, MyCustomAdmin)
+    +@admin.register(MyModel1, MyModel2)
+     class MyCustomAdmin(admin.ModelAdmin):
+         ...
+
+    -admin.site.register(MyModel1, MyCustomAdmin)
+    -admin.site.register(MyModel2, MyCustomAdmin)
 
 Django 1.9
 -----------

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -125,7 +125,7 @@ def visit_Call(
 
         elif (  # admin.site.register((MyModel1, MyModel2), MyCustomAdmin)
             len(node.args) == 2
-            and isinstance((model_tuple := node.args[0]), ast.Tuple)
+            and isinstance((model_tuple := node.args[0]), (ast.Tuple, ast.List))
             and all(isinstance(elt, ast.Name) for elt in model_tuple.elts)
             and isinstance((admin_arg := node.args[1]), ast.Name)
             and not node.keywords

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -83,13 +83,15 @@ def update_class_def(
     tokens: list[Token], i: int, *, name: str, state: State, decorated: bool
 ) -> None:
     model_names = decorable_admins.get(state, {}).pop(name, set())
-    if model_names:
-        if decorated:
-            i = reverse_find(tokens, i, name=OP, src="@")
-        j, indent = extract_indent(tokens, i)
-        joined_names = ", ".join(sorted(model_names))
-        new_src = f"{indent}@admin.register({joined_names})\n"
-        insert(tokens, j, new_src=new_src)
+    if not model_names:
+        return
+
+    if decorated:
+        i = reverse_find(tokens, i, name=OP, src="@")
+    j, indent = extract_indent(tokens, i)
+    joined_names = ", ".join(sorted(model_names))
+    new_src = f"{indent}@admin.register({joined_names})\n"
+    insert(tokens, j, new_src=new_src)
 
 
 @fixer.register(ast.Call)

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -87,11 +87,9 @@ def update_class_def(
         if decorated:
             i = reverse_find(tokens, i, name=OP, src="@")
         j, indent = extract_indent(tokens, i)
-        insert(
-            tokens,
-            j,
-            new_src=f"{indent}@admin.register({', '.join(sorted(model_names))})\n",
-        )
+        joined_names = ", ".join(sorted(model_names))
+        new_src = f"{indent}@admin.register({joined_names})\n"
+        insert(tokens, j, new_src=new_src)
 
 
 @fixer.register(ast.Call)

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -470,6 +470,55 @@ def test_custom_model_admin_base_class():
     )
 
 
+def test_multiple_model_multiline_registration():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.register(MyModel1, MyCustomAdmin)
+        admin.site.register(MyModel2, MyCustomAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        @admin.register(MyModel1, MyModel2)
+        class MyCustomAdmin:
+            pass
+
+        """,
+        settings=settings,
+    )
+
+
+def test_multiple_model_tuple_registration():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.register((MyModel1, MyModel2), MyCustomAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        @admin.register(MyModel1, MyModel2)
+        class MyCustomAdmin:
+            pass
+
+        """,
+        settings=settings,
+    )
+
+
 def test_complete():
     check_transformed(
         """\

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -503,6 +503,30 @@ def test_multiple_model_tuple_registration():
     )
 
 
+def test_multiple_model_list_registration():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.register([MyModel1, MyModel2], MyCustomAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        @admin.register(MyModel1, MyModel2)
+        class MyCustomAdmin:
+            pass
+
+        """,
+        settings=settings,
+    )
+
+
 def test_multiple_model_mixed_registration():
     check_transformed(
         """\

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -66,22 +66,6 @@ def test_already_using_decorator_registration():
     )
 
 
-def test_multiple_model_one_admin():
-    check_noop(
-        """\
-        from django.contrib import admin
-        from myapp.models import MyModel1, MyModel2
-
-        class MyCustomAdmin:
-            pass
-
-        admin.site.register(MyModel1, MyCustomAdmin)
-        admin.site.register(MyModel2, MyCustomAdmin)
-        """,
-        settings,
-    )
-
-
 def test_py2_style_init_super():
     check_noop(
         """\
@@ -542,6 +526,7 @@ def test_complete():
         from myapp.models import Author, Blog, MyModel1, MyModel2
         from myapp.admin import MyImportedAdmin
 
+        @admin.register(MyModel1, MyModel2)
         class MyCustomAdmin:
             pass
 
@@ -549,8 +534,6 @@ def test_complete():
         class AuthorAdmin(CustomModelAdmin):
             pass
 
-        admin.site.register(MyModel1, MyCustomAdmin)
-        admin.site.register(MyModel2, MyCustomAdmin)
         admin.site.register(Blog, MyImportedAdmin)
         """,
         settings=settings,

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -503,6 +503,31 @@ def test_multiple_model_tuple_registration():
     )
 
 
+def test_multiple_model_mixed_registration():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.register((MyModel1, MyModel2), MyCustomAdmin)
+        admin.site.register(MyModel3, MyCustomAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        @admin.register(MyModel1, MyModel2, MyModel3)
+        class MyCustomAdmin:
+            pass
+
+        """,
+        settings=settings,
+    )
+
+
 def test_complete():
     check_transformed(
         """\

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -479,6 +479,31 @@ def test_multiple_model_multiline_registration():
     )
 
 
+def test_multiple_model_multiline_registration_sorted():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.register(MyModel2, MyCustomAdmin)
+        admin.site.register(MyModel1, MyCustomAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        @admin.register(MyModel1, MyModel2)
+        class MyCustomAdmin:
+            pass
+
+        """,
+        settings=settings,
+    )
+
+
 def test_multiple_model_tuple_registration():
     check_transformed(
         """\
@@ -538,12 +563,13 @@ def test_multiple_model_mixed_registration():
 
         admin.site.register((MyModel1, MyModel2), MyCustomAdmin)
         admin.site.register(MyModel3, MyCustomAdmin)
+        admin.site.register([MyModel4], MyCustomAdmin)
         """,
         """\
         from django.contrib import admin
         from myapp.models import MyModel1, MyModel2
 
-        @admin.register(MyModel1, MyModel2, MyModel3)
+        @admin.register(MyModel1, MyModel2, MyModel3, MyModel4)
         class MyCustomAdmin:
             pass
 


### PR DESCRIPTION
Addresses point number 2 (Multiple model registration) of #190 

Following a review on the initial @admin.register fixer, I've also updated documentation links to `/en/stable/releases/` to remove yellow/red banners.

