### PR TITLE
Fix Content-Length and Content-Type

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,10 @@ History
 
 * Add Django 2.0+ fixer to drop assignments of ``allow_tags`` attributes to ``True``.
 
+* Make ``request.headers`` fixer also rewrite accesses of the ``Content-Length`` and ``Content-Type`` headers.
+
+  Thanks to Christian Bundy in `PR #226 <https://github.com/adamchainz/django-upgrade/pull/226>`__.
+
 * Make fixers that erase lines also erase any trailing comments.
 
 * Fix leaving a trailing comma when editing imports in certain cases.

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -20,6 +20,17 @@ fixer = Fixer(
     min_version=(2, 2),
 )
 
+def get_http_header_name(meta_name: str) -> str | None:
+    """Extract HTTP header name, unless it isn't an HTTP header."""
+    http_prefix = "HTTP_"
+    if meta_name.startswith(http_prefix):
+        return meta_name[len(http_prefix):]
+    if meta_name in {"CONTENT_LENGTH", "CONTENT_TYPE"}:
+        return meta_name
+    return None
+
+def is_http_header(meta_name: str) -> bool:
+    return get_http_header_name(meta_name) is not None
 
 @fixer.register(ast.Subscript)
 def visit_Subscript(
@@ -31,7 +42,7 @@ def visit_Subscript(
         not isinstance(parents[-1], ast.Assign)
         and is_request_or_self_request_meta(node.value)
         and (meta_name := extract_constant(node.slice)) is not None
-        and meta_name.startswith("HTTP_")
+        and is_http_header(meta_name)
     ):
         yield ast_start_offset(node), partial(
             rewrite_header_access, meta_name=meta_name
@@ -51,7 +62,7 @@ def visit_Call(
         and len(node.args) >= 1
         and isinstance(node.args[0], ast.Constant)
         and isinstance(meta_name := node.args[0].value, str)
-        and meta_name.startswith("HTTP_")
+        and is_http_header(meta_name)
     ):
         yield ast_start_offset(node), partial(
             rewrite_header_access, meta_name=meta_name
@@ -98,6 +109,6 @@ def rewrite_header_access(tokens: list[Token], i: int, *, meta_name: str) -> Non
     replace(tokens, meta_idx, src="headers")
 
     str_idx = find(tokens, meta_idx, name=STRING)
-    raw_header_name = meta_name[len("HTTP_") :]
+    raw_header_name = get_http_header_name(meta_name)
     header_name = "-".join(x.title() for x in raw_header_name.split("_"))
     replace(tokens, str_idx, src=repr(header_name))

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -20,17 +20,20 @@ fixer = Fixer(
     min_version=(2, 2),
 )
 
+
 def get_http_header_name(meta_name: str) -> str | None:
     """Extract HTTP header name, unless it isn't an HTTP header."""
     http_prefix = "HTTP_"
     if meta_name.startswith(http_prefix):
-        return meta_name[len(http_prefix):]
+        return meta_name[len(http_prefix) :]
     if meta_name in {"CONTENT_LENGTH", "CONTENT_TYPE"}:
         return meta_name
     return None
 
+
 def is_http_header(meta_name: str) -> bool:
     return get_http_header_name(meta_name) is not None
+
 
 @fixer.register(ast.Subscript)
 def visit_Subscript(

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -41,7 +41,7 @@ def visit_Subscript(
         not isinstance(parents[-1], ast.Assign)
         and is_request_or_self_request_meta(node.value)
         and (meta_name := extract_constant(node.slice)) is not None
-        and (raw_header_name := get_http_header_name(meta_name) is not None)
+        and (raw_header_name := get_http_header_name(meta_name)) is not None
     ):
         yield ast_start_offset(node), partial(
             rewrite_header_access, raw_header_name=raw_header_name
@@ -61,7 +61,7 @@ def visit_Call(
         and len(node.args) >= 1
         and isinstance(node.args[0], ast.Constant)
         and isinstance(meta_name := node.args[0].value, str)
-        and (raw_header_name := get_http_header_name(meta_name) is not None)
+        and (raw_header_name := get_http_header_name(meta_name)) is not None
     ):
         yield ast_start_offset(node), partial(
             rewrite_header_access, raw_header_name=raw_header_name

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -21,16 +21,6 @@ fixer = Fixer(
 )
 
 
-def get_http_header_name(meta_name: str) -> str | None:
-    """Extract HTTP header name, unless it isn't an HTTP header."""
-    http_prefix = "HTTP_"
-    if meta_name.startswith(http_prefix):
-        return meta_name[len(http_prefix) :]
-    if meta_name in {"CONTENT_LENGTH", "CONTENT_TYPE"}:
-        return meta_name
-    return None
-
-
 @fixer.register(ast.Subscript)
 def visit_Subscript(
     state: State,
@@ -101,6 +91,16 @@ else:
         ):
             return node.value.value
         return None
+
+
+def get_http_header_name(meta_name: str) -> str | None:
+    """Extract HTTP header name, unless it isn't an HTTP header."""
+    http_prefix = "HTTP_"
+    if meta_name.startswith(http_prefix):
+        return meta_name[len(http_prefix) :]
+    if meta_name in {"CONTENT_LENGTH", "CONTENT_TYPE"}:
+        return meta_name
+    return None
 
 
 def rewrite_header_access(tokens: list[Token], i: int, *, raw_header_name: str) -> None:

--- a/tests/fixers/test_request_headers.py
+++ b/tests/fixers/test_request_headers.py
@@ -91,6 +91,8 @@ def test_get_simple():
         """,
         settings,
     )
+
+
 def test_get_content_length():
     check_transformed(
         """\
@@ -101,6 +103,8 @@ def test_get_content_length():
         """,
         settings,
     )
+
+
 def test_get_content_type():
     check_transformed(
         """\

--- a/tests/fixers/test_request_headers.py
+++ b/tests/fixers/test_request_headers.py
@@ -9,7 +9,7 @@ settings = Settings(target_version=(2, 2))
 def test_not_header_access():
     check_noop(
         """\
-        request.META['CONTENT_LENGTH']
+        request.META['QUERY_STRING']
         """,
         settings,
     )
@@ -88,6 +88,26 @@ def test_get_simple():
         """,
         """\
         request.headers.get('Server')
+        """,
+        settings,
+    )
+def test_get_content_length():
+    check_transformed(
+        """\
+        request.META.get('CONTENT_LENGTH')
+        """,
+        """\
+        request.headers.get('Content-Length')
+        """,
+        settings,
+    )
+def test_get_content_type():
+    check_transformed(
+        """\
+        request.META.get('CONTENT_TYPE')
+        """,
+        """\
+        request.headers.get('Content-Type')
         """,
         settings,
     )


### PR DESCRIPTION
Problem: Both Content-Length and Content-Type are HTTP headers, but they aren't picked up by the request header fixer because they don't start with the usual `HTTP_` prefix.

Solution: Add failing tests and then fix them by checking for either the usual `HTTP_` prefix or comparing against the set of these two exceptional cases.

Fixes: https://github.com/adamchainz/django-upgrade/issues/224