### PR TITLE
Support custom admin classes in @admin.register fixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,23 @@ __ https://docs.djangoproject.com/en/stable/ref/contrib/admin/#the-register-deco
     -admin.site.register(MyModel1, MyCustomAdmin)
     -admin.site.register(MyModel2, MyCustomAdmin)
 
+
+This also works with custom admin sites.
+We are detecting them heuristically by matching object names ending with ``site``, registered admin models ending with ``Admin`` and filenames called ``admin.py`` (or in an ``admin`` directory).
+
+.. code-block:: diff
+
+    from myapp.admin import custom_site
+    from django.contrib import admin
+
+    +@admin.register(MyModel)
+    +@admin.register(MyModel, site=custom_site)
+    class MyModelAdmin(admin.ModelAdmin):
+        pass
+
+    -custom_site.register(MyModel, MyModelAdmin)
+    -admin.site.register(MyModel, MyModelAdmin)
+
 Django 1.9
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,11 @@ __ https://docs.djangoproject.com/en/stable/ref/contrib/admin/#the-register-deco
 
 
 This also works with custom admin sites.
-We are detecting them heuristically by matching object names ending with ``site``, registered admin models ending with ``Admin`` and filenames called ``admin.py`` (or in an ``admin`` directory).
+Such calls are detected heuristically based on three criteria:
+
+1. The object whose ``register()`` method is called has a name ending with ``site``.
+2. The registered class has a name ending with ``Admin``.
+3. The filename has the word ``admin`` somewhere in its path.
 
 .. code-block:: diff
 

--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,6 @@ __ https://docs.djangoproject.com/en/stable/ref/contrib/admin/#the-register-deco
     -admin.site.register(MyModel1, MyCustomAdmin)
     -admin.site.register(MyModel2, MyCustomAdmin)
 
-
 This also works with custom admin sites.
 Such calls are detected heuristically based on three criteria:
 

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -30,7 +30,7 @@ class Settings:
 
 settings_re = re.compile(r"\bsettings\b")
 
-admin_re = re.compile(r"\badmin\b")
+admin_re = re.compile(r"(\b|_)admin(\b|_)")
 
 test_re = re.compile(r"(\b|_)tests?(\b|_)")
 

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -30,6 +30,8 @@ class Settings:
 
 settings_re = re.compile(r"\bsettings\b")
 
+admin_re = re.compile(r"\badmin\b")
+
 test_re = re.compile(r"(\b|_)tests?(\b|_)")
 
 dunder_init_re = re.compile(r"(^|[\\/])__init__\.py$")
@@ -61,6 +63,9 @@ class State:
 
     def looks_like_settings_file(self) -> bool:
         return settings_re.search(self.filename) is not None
+
+    def looks_like_admin_file(self) -> bool:
+        return admin_re.search(self.filename) is not None
 
     def looks_like_test_file(self) -> bool:
         return test_re.search(self.filename) is not None

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -665,7 +665,7 @@ def test_custom_admin_not_an_admin_file():
         custom_site.register(MyModel, MyModelAdmin)
         """,
         settings,
-        filename="definitely_not_an_admin_file.py",
+        filename="a_d_m_i_n.py",
     )
 
 
@@ -776,7 +776,7 @@ def test_multiple_admin_sites_not_admin_file():
         custom_site.register(MyModel, MyModelAdmin)
         """,
         settings=settings,
-        filename="definitely_not_an_admin_file.py",
+        filename="a_d_m_i_n.py",
     )
 
 

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -653,7 +653,55 @@ def test_complete():
     )
 
 
-def test_custom_admin_site_simple():
+def test_custom_admin_not_an_admin_file():
+    check_noop(
+        """\
+        from myapp.admin import MyModel, CustomModelAdmin, custom_site
+        from django.contrib import admin
+
+        class MyModelAdmin(CustomModelAdmin):
+            pass
+
+        custom_site.register(MyModel, MyModelAdmin)
+        """,
+        settings,
+        filename="definitely_not_an_admin_file.py",
+    )
+
+
+def test_custom_admin_not_an_admin_model():
+    check_noop(
+        """\
+        from myapp.admin import MyModel, CustomModel, custom_site
+        from django.contrib import admin
+
+        class Custom(MyModel):
+            pass
+
+        custom_site.register(MyModel, Custom)
+        """,
+        settings,
+        filename="admin.py",
+    )
+
+
+def test_custom_admin_doesnt_end_with_site():
+    check_noop(
+        """\
+        from myapp.admin import MyModel, CustomModelAdmin, app
+        from django.contrib import admin
+
+        class MyModelAdmin(CustomModelAdmin):
+            pass
+
+        app.register(MyModel, MyModelAdmin)
+        """,
+        settings,
+        filename="admin.py",
+    )
+
+
+def test_custom_admin_site():
     check_transformed(
         """\
         from myapp.admin import custom_site, CustomModelAdmin
@@ -665,7 +713,7 @@ def test_custom_admin_site_simple():
         custom_site.register(MyModel, MyModelAdmin)
         """,
         """\
-        from myapp.admin import custom_site
+        from myapp.admin import custom_site, CustomModelAdmin
         from django.contrib import admin
 
         @admin.register(MyModel, site=custom_site)
@@ -674,4 +722,88 @@ def test_custom_admin_site_simple():
 
         """,
         settings=settings,
+        filename="admin.py",
+    )
+
+
+def test_multiple_admin_sites():
+    check_transformed(
+        """\
+        from myapp.admin import custom_site
+        from django.contrib import admin
+
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        custom_site.register(MyModel, MyModelAdmin)
+        admin.site.register(MyModel, MyModelAdmin)
+        """,
+        """\
+        from myapp.admin import custom_site
+        from django.contrib import admin
+
+        @admin.register(MyModel)
+        @admin.register(MyModel, site=custom_site)
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
+def test_multiple_admin_sites_not_admin_file():
+    check_transformed(
+        """\
+        from myapp.admin import custom_site
+        from django.contrib import admin
+
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        custom_site.register(MyModel, MyModelAdmin)
+        admin.site.register(MyModel, MyModelAdmin)
+        """,
+        """\
+        from myapp.admin import custom_site
+        from django.contrib import admin
+
+        @admin.register(MyModel)
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        custom_site.register(MyModel, MyModelAdmin)
+        """,
+        settings=settings,
+        filename="definitely_not_an_admin_file.py",
+    )
+
+
+def test_multiple_admin_sites_sorted():
+    check_transformed(
+        """\
+        from myapp.admin import custom_site, secret_site
+        from django.contrib import admin
+
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        admin.site.register(MyModel, MyModelAdmin)
+        custom_site.register(MyModel, MyModelAdmin)
+        secret_site.register(MyModel, MyModelAdmin)
+        """,
+        """\
+        from myapp.admin import custom_site, secret_site
+        from django.contrib import admin
+
+        @admin.register(MyModel)
+        @admin.register(MyModel, site=custom_site)
+        @admin.register(MyModel, site=secret_site)
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        """,
+        settings=settings,
+        filename="admin.py",
     )

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -651,3 +651,27 @@ def test_complete():
         """,
         settings=settings,
     )
+
+
+def test_custom_admin_site_simple():
+    check_transformed(
+        """\
+        from myapp.admin import custom_site, CustomModelAdmin
+        from django.contrib import admin
+
+        class MyModelAdmin(CustomModelAdmin):
+            pass
+
+        custom_site.register(MyModel, MyModelAdmin)
+        """,
+        """\
+        from myapp.admin import custom_site
+        from django.contrib import admin
+
+        @admin.register(MyModel, site=custom_site)
+        class MyModelAdmin(CustomModelAdmin):
+            pass
+
+        """,
+        settings=settings,
+    )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -134,6 +134,10 @@ def test_looks_like_dunder_init_file_false(filename: str) -> None:
         "myapp/admin.py",
         "myapp/admin/file.py",
         "myapp/blog/admin/article.py",
+        "myapp/custom_admin.py",
+        "myapp/custom_admin/file.py",
+        "myapp/admin_custom.py",
+        "myapp/admin_custom/file.py",
     ),
 )
 def test_looks_like_admin_file_true(filename: str) -> None:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -125,3 +125,37 @@ def test_looks_like_dunder_init_file_false(filename: str) -> None:
         from_imports=defaultdict(set),
     )
     assert not state.looks_like_dunder_init_file()
+
+
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "admin.py",
+        "myapp/admin.py",
+        "myapp/admin/file.py",
+        "myapp/blog/admin/article.py",
+    ),
+)
+def test_looks_like_admin_file_true(filename: str) -> None:
+    state = State(
+        settings=Settings(target_version=(4, 0)),
+        filename=filename,
+        from_imports=defaultdict(set),
+    )
+    assert state.looks_like_admin_file()
+
+
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "administrator.py",
+        "blog/adm/article.py",
+    ),
+)
+def test_looks_like_admin_file_false(filename: str) -> None:
+    state = State(
+        settings=Settings(target_version=(4, 0)),
+        filename=filename,
+        from_imports=defaultdict(set),
+    )
+    assert not state.looks_like_admin_file()


### PR DESCRIPTION
For #190

Hey, so I started working on the custom admin support and I had a few interrogations to finish it. 

1. Is a stacked syntax ok when the same admin model is used to register a model against different sites ? 

``` diff
class MyAdminSite(admin.AdminSite):
    site_header = "My very custom administration"

custom_site = MyAdminSite(name="myadmin")

+@admin.register(Comment)
+@admin.register(Comment, site=custom_site)
class CommentAdmin(admin.ModelAdmin):
    pass


-admin.site.register(Comment, CommentAdmin)
-custom_site.register(Comment, CommentAdmin)
```

2. What should I do if `from django.contrib import admin` is missing (I suppose it's quitte common if you work with custom sites). I'm not sure where to add the import

3. Should we extend the `looks_like_admin_file` check heuristic to the regular fixers too ?