### PR TITLE
Extend `on_delete` fixer to support import from `django.db.models`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,7 +20,7 @@ History
 
 * Make ``on_delete`` fixer also support ``ForeignKey`` and ``OneToOneField`` imported from ``django.db.models``.
 
-  Thanks to Thibaut Decombe in `PR #234 <https://github.com/adamchainz/django-upgrade/pull/234>`__.
+  Thanks to Thibaut Decombe in `PR #236 <https://github.com/adamchainz/django-upgrade/pull/236>`__.
 
 * Make fixers that erase lines also erase any trailing comments.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,10 @@ History
 
   Thanks to Christian Bundy in `PR #226 <https://github.com/adamchainz/django-upgrade/pull/226>`__.
 
+* Make ``on_delete`` fixer also support ``ForeignKey`` and ``OneToOneField`` imported from ``django.db.models``.
+
+  Thanks to Thibaut Decombe in `PR #234 <https://github.com/adamchainz/django-upgrade/pull/234>`__.
+
 * Make fixers that erase lines also erase any trailing comments.
 
 * Fix leaving a trailing comma when editing imports in certain cases.

--- a/README.rst
+++ b/README.rst
@@ -183,23 +183,23 @@ Add ``on_delete=models.CASCADE`` to ``ForeignKey`` and ``OneToOneField``:
 
 .. code-block:: diff
 
+     from django.db import models
+
     -models.ForeignKey("auth.User")
     +models.ForeignKey("auth.User", on_delete=models.CASCADE)
 
     -models.OneToOneField("auth.User")
     +models.OneToOneField("auth.User", on_delete=models.CASCADE)
 
-This fixer also support import from ``django.db.models``:
+This fixer also support from-imports:
 
 .. code-block:: diff
 
-    -from django.db.models import ForeignKey, OneToOneField
-    +from django.db.models import CASCADE, ForeignKey, OneToOneField
+    -from django.db.models import ForeignKey
+    +from django.db.models import CASCADE, ForeignKey
 
     -ForeignKey("auth.User")
     +ForeignKey("auth.User", on_delete=CASCADE)
-    -OneToOneField("auth.User")
-    +OneToOneField("auth.User", on_delete=CASCADE)
 
 Compatibility imports
 ~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,18 @@ Add ``on_delete=models.CASCADE`` to ``ForeignKey`` and ``OneToOneField``:
     -models.OneToOneField("auth.User")
     +models.OneToOneField("auth.User", on_delete=models.CASCADE)
 
+This fixer also support import from ``django.db.models``:
+
+.. code-block:: diff
+
+    -from django.db.models import ForeignKey, OneToOneField
+    +from django.db.models import CASCADE, ForeignKey, OneToOneField
+
+    -ForeignKey("auth.User")
+    +ForeignKey("auth.User", on_delete=CASCADE)
+    -OneToOneField("auth.User")
+    +OneToOneField("auth.User", on_delete=CASCADE)
+
 Compatibility imports
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/django_upgrade/fixers/on_delete.py
+++ b/src/django_upgrade/fixers/on_delete.py
@@ -13,14 +13,7 @@ from tokenize_rt import Offset, Token
 
 from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
 from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    OP,
-    erase_node,
-    extract_indent,
-    find,
-    insert,
-    parse_call_args,
-)
+from django_upgrade.tokens import OP, extract_indent, find, insert, parse_call_args
 
 fixer = Fixer(
     __name__,
@@ -53,17 +46,13 @@ should_update_import: MutableMapping[State, bool] = WeakKeyDictionary()
 def update_django_models_import(
     tokens: list[Token], i: int, *, node: ast.ImportFrom, state: State
 ) -> None:
-    if should_update_import.pop(state, False):
-        used_names = state.from_imports["django.db.models"]
-        used_names.add("CASCADE")
-
+    if should_update_import.get(state, False):
+        should_update_import[state] = False
         j, indent = extract_indent(tokens, i)
-        erase_node(tokens, i, node=node)
-        joined_names = ", ".join(sorted(used_names))
         insert(
             tokens,
             j,
-            new_src=f"{indent}from django.db.models import {joined_names}\n",
+            new_src=f"{indent}from django.db.models import CASCADE\n",
         )
 
 

--- a/tests/fixers/test_on_delete.py
+++ b/tests/fixers/test_on_delete.py
@@ -58,8 +58,28 @@ def test_field_class_imported(field_class: str) -> None:
         {field_class}("auth.User")
         """,
         f"""\
-        from django.db.models import CASCADE, {field_class}
+        from django.db.models import CASCADE
+        from django.db.models import {field_class}
         {field_class}("auth.User", on_delete=CASCADE)
+        """,
+        settings,
+    )
+
+
+def test_both_field_classes_imported() -> None:
+    check_transformed(
+        """\
+        from django.db.models import ForeignKey
+        from django.db.models import OneToOneField
+        ForeignKey("auth.User")
+        OneToOneField("auth.User")
+        """,
+        """\
+        from django.db.models import ForeignKey
+        from django.db.models import CASCADE
+        from django.db.models import OneToOneField
+        ForeignKey("auth.User", on_delete=CASCADE)
+        OneToOneField("auth.User", on_delete=CASCADE)
         """,
         settings,
     )
@@ -223,27 +243,10 @@ def test_mixed_imports():
         """,
         """\
         from django.db import models
-        from django.db.models import CASCADE, ForeignKey
+        from django.db.models import CASCADE
+        from django.db.models import ForeignKey
 
         models.OneToOneField(on_delete=models.CASCADE, to="auth.User")
-        ForeignKey(on_delete=CASCADE, to="auth.User", null=True, blank=True)
-        """,
-        settings,
-    )
-
-
-def test_sorted_imports():
-    check_transformed(
-        """\
-        from django.db.models import OneToOneField, ForeignKey
-
-        OneToOneField(to="auth.User")
-        ForeignKey(to="auth.User", null=True, blank=True)
-        """,
-        """\
-        from django.db.models import CASCADE, ForeignKey, OneToOneField
-
-        OneToOneField(on_delete=CASCADE, to="auth.User")
         ForeignKey(on_delete=CASCADE, to="auth.User", null=True, blank=True)
         """,
         settings,

--- a/tests/fixers/test_on_delete.py
+++ b/tests/fixers/test_on_delete.py
@@ -20,25 +20,61 @@ def test_argument_already_set(field_class: str) -> None:
 
 
 @pytest.mark.parametrize("field_class", ["ForeignKey", "OneToOneField"])
-def test_field_class_imported(field_class: str) -> None:
+def test_argument_already_set_other_import_style(field_class: str) -> None:
     check_noop(
         f"""\
         from django.db.models import {field_class}
-        {field_class}("auth.User")
+        {field_class}("auth.User", on_delete=models.SET_NULL)
         """,
         settings,
     )
 
 
-def test_foreignkey_with_args():
-    check_transformed(
+def test_foreign_key_with_two_args():
+    check_noop(
         """\
         from django.db import models
-        models.ForeignKey("auth.User")
+        models.ForeignKey("auth.User", models.SET_NULL)
         """,
+        settings,
+    )
+
+
+def test_foreign_key_unused() -> None:
+    check_noop(
         """\
+        from django.db.models import IntegerField
+        IntegerField()
+        """,
+        settings,
+    )
+
+
+@pytest.mark.parametrize("field_class", ["ForeignKey", "OneToOneField"])
+def test_field_class_imported(field_class: str) -> None:
+    check_transformed(
+        f"""\
+        from django.db.models import {field_class}
+        {field_class}("auth.User")
+        """,
+        f"""\
+        from django.db.models import CASCADE, {field_class}
+        {field_class}("auth.User", on_delete=CASCADE)
+        """,
+        settings,
+    )
+
+
+@pytest.mark.parametrize("field_class", ["ForeignKey", "OneToOneField"])
+def test_field_class_with_args(field_class):
+    check_transformed(
+        f"""\
         from django.db import models
-        models.ForeignKey("auth.User", on_delete=models.CASCADE)
+        models.{field_class}("auth.User")
+        """,
+        f"""\
+        from django.db import models
+        models.{field_class}("auth.User", on_delete=models.CASCADE)
         """,
         settings,
     )
@@ -53,6 +89,20 @@ def test_foreignkey_with_args_ending_comma():
         """\
         from django.db import models
         models.ForeignKey("auth.User", on_delete=models.CASCADE)
+        """,
+        settings,
+    )
+
+
+def test_foreignkey_with_args_and_kwargs():
+    check_transformed(
+        """\
+        from django.db import models
+        models.ForeignKey("auth.User", blank=True, null=True)
+        """,
+        """\
+        from django.db import models
+        models.ForeignKey("auth.User", on_delete=models.CASCADE, blank=True, null=True)
         """,
         settings,
     )
@@ -104,22 +154,6 @@ def test_foreignkey_with_kwargs_ending_comma():
     )
 
 
-def test_one_to_one_with_args():
-    check_transformed(
-        """\
-        from django.db import models
-
-        models.OneToOneField("auth.User")
-        """,
-        """\
-        from django.db import models
-
-        models.OneToOneField("auth.User", on_delete=models.CASCADE)
-        """,
-        settings,
-    )
-
-
 def test_one_to_one_with_arg_whitespace():
     check_transformed(
         """\
@@ -127,14 +161,36 @@ def test_one_to_one_with_arg_whitespace():
 
         models.OneToOneField(
             "auth.User"
-            )
+        )
         """,
         """\
         from django.db import models
 
         models.OneToOneField(
             "auth.User"
-            , on_delete=models.CASCADE)
+        , on_delete=models.CASCADE)
+        """,
+        settings,
+    )
+
+
+def test_multiline_foreign_key_def():
+    check_transformed(
+        """\
+        from django.db import models
+
+        models.ForeignKey(
+            "auth.User",
+            verbose_name="User"
+        )
+        """,
+        """\
+        from django.db import models
+
+        models.ForeignKey(
+            "auth.User", on_delete=models.CASCADE,
+            verbose_name="User"
+        )
         """,
         settings,
     )
@@ -151,6 +207,44 @@ def test_one_to_one_with_kwargs():
         from django.db import models
 
         models.OneToOneField(on_delete=models.CASCADE, to="auth.User")
+        """,
+        settings,
+    )
+
+
+def test_mixed_imports():
+    check_transformed(
+        """\
+        from django.db import models
+        from django.db.models import ForeignKey
+
+        models.OneToOneField(to="auth.User")
+        ForeignKey(to="auth.User", null=True, blank=True)
+        """,
+        """\
+        from django.db import models
+        from django.db.models import CASCADE, ForeignKey
+
+        models.OneToOneField(on_delete=models.CASCADE, to="auth.User")
+        ForeignKey(on_delete=CASCADE, to="auth.User", null=True, blank=True)
+        """,
+        settings,
+    )
+
+
+def test_sorted_imports():
+    check_transformed(
+        """\
+        from django.db.models import OneToOneField, ForeignKey
+
+        OneToOneField(to="auth.User")
+        ForeignKey(to="auth.User", null=True, blank=True)
+        """,
+        """\
+        from django.db.models import CASCADE, ForeignKey, OneToOneField
+
+        OneToOneField(on_delete=CASCADE, to="auth.User")
+        ForeignKey(on_delete=CASCADE, to="auth.User", null=True, blank=True)
         """,
         settings,
     )


### PR DESCRIPTION
Fixes #62 

I also tweaked the `add_on_delete_keyword` function that was producing some extra spaces in some cases.
I've added tests to cover these cases.