### PR TITLE
Make admin.register fixer skip unregistered models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,7 +197,6 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
 
     from django.contrib import admin
 
-
     class MyCustomAdmin(admin.ModelAdmin):
         ...
 

--- a/README.rst
+++ b/README.rst
@@ -197,8 +197,10 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
 
     from django.contrib import admin
 
+
     class MyCustomAdmin(admin.ModelAdmin):
         ...
+
 
     admin.site.unregister(MyModel1)
     admin.site.register(MyModel1, MyCustomAdmin)

--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,7 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
     class MyCustomAdmin(admin.ModelAdmin):
         ...
 
+
     admin.site.unregister(MyModel1)
     admin.site.register(MyModel1, MyCustomAdmin)
 

--- a/README.rst
+++ b/README.rst
@@ -204,7 +204,6 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
     admin.site.unregister(MyModel1)
     admin.site.register(MyModel1, MyCustomAdmin)
 
-
 Django 1.9
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,7 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
 
     from django.contrib import admin
 
+
     class MyCustomAdmin(admin.ModelAdmin):
         ...
 

--- a/README.rst
+++ b/README.rst
@@ -197,14 +197,11 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
 
     from django.contrib import admin
 
-
     class MyCustomAdmin(admin.ModelAdmin):
         ...
 
-
     admin.site.unregister(MyModel1)
     admin.site.register(MyModel1, MyCustomAdmin)
-
 
 
 Django 1.9

--- a/README.rst
+++ b/README.rst
@@ -201,7 +201,6 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
     class MyCustomAdmin(admin.ModelAdmin):
         ...
 
-
     admin.site.unregister(MyModel1)
     admin.site.register(MyModel1, MyCustomAdmin)
 

--- a/README.rst
+++ b/README.rst
@@ -197,10 +197,8 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
 
     from django.contrib import admin
 
-
     class MyCustomAdmin(admin.ModelAdmin):
         ...
-
 
     admin.site.unregister(MyModel1)
     admin.site.register(MyModel1, MyCustomAdmin)

--- a/README.rst
+++ b/README.rst
@@ -191,6 +191,20 @@ Such calls are detected heuristically based on three criteria:
     -custom_site.register(MyModel, MyModelAdmin)
     -admin.site.register(MyModel, MyModelAdmin)
 
+If a ``register()`` call is preceded by an ``unregister()`` call that includes the same model, it is ignored.
+
+.. code-block:: python
+
+    from django.contrib import admin
+
+    class MyCustomAdmin(admin.ModelAdmin):
+        ...
+
+    admin.site.unregister(MyModel1)
+    admin.site.register(MyModel1, MyCustomAdmin)
+
+
+
 Django 1.9
 -----------
 

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -183,7 +183,8 @@ def visit_Call(
             )
             num_intersections = len(model_names & unregistered_models)
             if (
-                # We do not rewrite register calls that contain at least one unregistered model.
+                # We do not rewrite register calls that contain at least one
+                # unregistered model.
                 num_intersections == 0
                 and admin_details is not None
                 and admin_details.parent == parents[-2]
@@ -209,7 +210,7 @@ def visit_Call(
                     and state.looks_like_admin_file()
                 )
             )
-            and (  # unregister(…) has only one parameter, a model or a sequence of models
+            and (  # unregister(…) has only one parameter
                 isinstance((first_arg := node.args[0]), ast.Name)
                 or (
                     isinstance(first_arg, (ast.Tuple, ast.List))

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -1004,7 +1004,7 @@ def test_unregister_undetectable_names():
 
 
 def test_unregister_multiple_admins():
-    check_transformed(
+    check_noop(
         """\
         from django.contrib import admin
         from myapp.models import MyModel1, MyModel2
@@ -1019,21 +1019,6 @@ def test_unregister_multiple_admins():
             pass
 
         admin.site.register(MyModel1, MyOtherCustomAdmin)
-        """,
-        """\
-        from django.contrib import admin
-        from myapp.models import MyModel1, MyModel2
-
-        class MyCustomAdmin:
-            pass
-
-        admin.site.unregister(MyModel1)
-        admin.site.register(MyModel1, MyCustomAdmin)
-
-        @admin.register(MyModel1)
-        class MyOtherCustomAdmin:
-            pass
-
         """,
         settings=settings,
         filename="admin.py",

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -674,7 +674,7 @@ def test_multiple_model_mixed_registration():
     check_transformed(
         """\
         from django.contrib import admin
-        from myapp.models import MyModel1, MyModel2
+        from myapp.models import MyModel1, MyModel2, MyModel3, MyModel4
 
         class MyCustomAdmin:
             pass
@@ -685,7 +685,7 @@ def test_multiple_model_mixed_registration():
         """,
         """\
         from django.contrib import admin
-        from myapp.models import MyModel1, MyModel2
+        from myapp.models import MyModel1, MyModel2, MyModel3, MyModel4
 
         @admin.register(MyModel1, MyModel2, MyModel3, MyModel4)
         class MyCustomAdmin:
@@ -886,4 +886,194 @@ def test_multiple_admin_sites_sorted():
         """,
         settings=settings,
         filename="admin.py",
+    )
+
+
+def test_unregister():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister(MyModel1)
+        admin.site.register(MyModel1, MyCustomAdmin)
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
+def test_unregister_no_effect_if_register_precedes():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.register(MyModel1, MyCustomAdmin)
+        admin.site.unregister(MyModel1)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1
+
+        @admin.register(MyModel1)
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister(MyModel1)
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
+def test_unregister_at_least_one_model_leaves_register():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister([MyModel1])
+        admin.site.register([MyModel1, MyModel2], MyCustomAdmin)
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
+def test_unregister_multiple_admins():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister(MyModel1)
+        admin.site.register(MyModel1, MyCustomAdmin)
+
+        class MyOtherCustomAdmin:
+            pass
+
+        admin.site.register(MyModel2, MyOtherCustomAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister(MyModel1)
+        admin.site.register(MyModel1, MyCustomAdmin)
+
+        @admin.register(MyModel2)
+        class MyOtherCustomAdmin:
+            pass
+
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
+def test_unregister_multiple_models_for_model_admin():
+    check_transformed(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2, MyModel3, MyModel4
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister([MyModel1, MyModel2])
+        admin.site.register((MyModel1, MyModel2), MyCustomAdmin)
+        admin.site.register(MyModel3, MyCustomAdmin)
+        admin.site.register([MyModel4], MyCustomAdmin)
+        """,
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2, MyModel3, MyModel4
+
+        @admin.register(MyModel3, MyModel4)
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister([MyModel1, MyModel2])
+        admin.site.register((MyModel1, MyModel2), MyCustomAdmin)
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
+def test_unregister_custom_admin_unregister():
+    check_transformed(
+        """\
+        from myapp.admin import custom_site, secret_site
+        from django.contrib import admin
+
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        admin.site.register(MyModel, MyModelAdmin)
+        custom_site.unregister([MyModel])
+        custom_site.register(MyModel, MyModelAdmin)
+        secret_site.register(MyModel, MyModelAdmin)
+        """,
+        """\
+        from myapp.admin import custom_site, secret_site
+        from django.contrib import admin
+
+        @admin.register(MyModel)
+        @admin.register(MyModel, site=secret_site)
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        custom_site.unregister([MyModel])
+        custom_site.register(MyModel, MyModelAdmin)
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
+def test_unregister_not_admin_file():
+    check_transformed(
+        """\
+        from myapp.admin import custom_site, secret_site
+        from django.contrib import admin
+
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        admin.site.register(MyModel, MyModelAdmin)
+        custom_site.unregister(MyModel)
+        custom_site.register(MyModel, MyModelAdmin)
+        secret_site.register(MyModel, MyModelAdmin)
+        """,
+        """\
+        from myapp.admin import custom_site, secret_site
+        from django.contrib import admin
+
+        @admin.register(MyModel)
+        class MyModelAdmin(admin.ModelAdmin):
+            pass
+
+        custom_site.unregister(MyModel)
+        custom_site.register(MyModel, MyModelAdmin)
+        secret_site.register(MyModel, MyModelAdmin)
+        """,
+        settings=settings,
+        filename="a_d_m_i_n.py",
     )

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -1003,6 +1003,24 @@ def test_unregister_undetectable_names():
     )
 
 
+def test_unregister_undetectable_names_and_more():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1, MyModel2
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister(*some_models())
+        admin.site.unregister(MyModel2)
+        admin.site.register(MyModel1, MyCustomAdmin)
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
 def test_unregister_multiple_admins():
     check_noop(
         """\

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -906,6 +906,25 @@ def test_unregister():
     )
 
 
+def test_unregister_reoccurring():
+    check_noop(
+        """\
+        from django.contrib import admin
+        from myapp.models import MyModel1
+
+        class MyCustomAdmin:
+            pass
+
+        admin.site.unregister(MyModel1)
+        admin.site.register(MyModel1, MyCustomAdmin)
+        admin.site.unregister(MyModel1)
+        admin.site.register(MyModel1, MyCustomAdmin)
+        """,
+        settings=settings,
+        filename="admin.py",
+    )
+
+
 def test_unregister_no_effect_if_register_precedes():
     check_transformed(
         """\


### PR DESCRIPTION
Updates the "register admin" fixer to ignore register calls if preceded by an unregister.

Closes #239 