### PR TITLE
Improve installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,6 @@ You can install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hoo
         hooks:
         -   id: django-upgrade
             args: [--target-version, "4.1"]   # Replace with Django version
-            types: [file, python]
 
 To upgrade your entire project immediately, you can tell pre-commit to run the ``django-upgrade`` hook on all files. Once you commit these changes, your other pre-commit linters will execute and you may see further changes. Use the following command:
 

--- a/README.rst
+++ b/README.rst
@@ -23,13 +23,7 @@ Automatically upgrade your Django project code.
 Installation
 ============
 
-There are several ways to install and use django-upgrade, here are two common scenarios.
-
-
-Option 1: pip
--------------
-
-Install the ``django-upgrade`` command with pip. See **Usage** for an introduction to the ``django-upgrade`` command.
+Use **pip**:
 
 .. code-block:: sh
 
@@ -37,32 +31,31 @@ Install the ``django-upgrade`` command with pip. See **Usage** for an introducti
 
 Python 3.8 to 3.11 supported.
 
+pre-commit hook
+---------------
 
-Option 2: pre-commit
---------------------
-
-You can install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook. Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
+You can also install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook.
+Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__), above any code formatters (such as Black):
 
 .. code-block:: yaml
 
     -   repo: https://github.com/adamchainz/django-upgrade
-        rev: ''  # replace with latest tag on GitHub
+        rev: ""  # replace with latest tag on GitHub
         hooks:
         -   id: django-upgrade
             args: [--target-version, "4.1"]   # Replace with Django version
 
-To upgrade your entire project immediately, you can tell pre-commit to run the ``django-upgrade`` hook on all files. Once you commit these changes, your other pre-commit linters will execute and you may see further changes. Use the following command:
+Then, upgrade your entire project:
 
 .. code-block:: sh
 
     pre-commit run django-upgrade --all-files
 
-----
+Commit any changes.
+In the process, your other hooks will run, potentially reformatting django-upgrade’s changes to match your project’s code style.
 
-**Tip:** Leaving this hook in place after the upgrade process is considered entirely safe and actually recommended! Django-upgrade may receive future improvements and thus keep improving your code.
-
-**Tip:** Pre-commit can help you update to the latest ``django-upgrade`` version with its ``autoupdate`` command. Normally, pre-commit will run exactly on the files that you have changed in your commit. This is a sufficient flow for most cases, but remember to also run ``pre-commit run django-upgrade --all-files`` as django-upgrade may add new improvements in each release.
-
+Keep the hook installed in order to upgrade all code added to your project.
+pre-commit’s ``autoupdate`` command will also let you take advantage of future django-upgrade features.
 
 ----
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Installation
 
 Python 3.8 to 3.11 supported. See **Usage** for an introduction to the ``django-upgrade`` command.
 
-**Option 2**: You can install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook. Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
+**Option 2**: Install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook. Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
 
 .. code-block:: yaml
 

--- a/README.rst
+++ b/README.rst
@@ -23,15 +23,15 @@ Automatically upgrade your Django project code.
 Installation
 ============
 
-Use **pip**:
+**Option 1**: Install django-upgrade with **pip**:
 
 .. code-block:: sh
 
     python -m pip install django-upgrade
 
-Python 3.8 to 3.11 supported.
+Python 3.8 to 3.11 supported. See **Usage** for an introduction to the ``django-upgrade`` command.
 
-Or with `pre-commit <https://pre-commit.com/>`__ in the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
+**Option 2**: You can also install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook. Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
 
 .. code-block:: yaml
 
@@ -41,12 +41,14 @@ Or with `pre-commit <https://pre-commit.com/>`__ in the ``repos`` section of you
         -   id: django-upgrade
             args: [--target-version, "4.1"]   # Replace with Django version
 
-
-To upgrade your entire project run:
+To upgrade your entire project immediately, you can tell pre-commit to run the ``django-upgrade`` hook on all files. Once you commit these changes, your other pre-commit linters will execute and you may see further changes. Use the following command:
 
 .. code-block:: sh
 
     pre-commit run django-upgrade --all-files
+
+Tip: You may comment out this hook once your upgrade process has finished, but leaving it in place is considered entirely safe, as django-upgrade may receive future improvements and thus keep improving your code.
+
 
 ----
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Installation
 
 Python 3.8 to 3.11 supported. See **Usage** for an introduction to the ``django-upgrade`` command.
 
-**Option 2**: You can also install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook. Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
+**Option 2**: You can install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook. Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
 
 .. code-block:: yaml
 
@@ -48,7 +48,9 @@ To upgrade your entire project immediately, you can tell pre-commit to run the `
 
     pre-commit run django-upgrade --all-files
 
-Tip: You may comment out this hook once your upgrade process has finished, but leaving it in place is considered entirely safe, as django-upgrade may receive future improvements and thus keep improving your code.
+.. tip:: Leaving this hook in place after the upgrade process is considered entirely safe and actually recommended! Django-upgrade may receive future improvements and thus keep improving your code.
+
+.. tip:: Normally, pre-commit will run exactly on the files that you have changed in your commit. Pre-commit can also help you update to the latest ``django-upgrade`` version with its ``autoupdate`` command. This is a sufficient flow for most cases, but remember to also run ``pre-commit run django-upgrade --all-files`` as django-upgrade may add new improvements in each release.
 
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -23,15 +23,25 @@ Automatically upgrade your Django project code.
 Installation
 ============
 
-**Option 1**: Install django-upgrade with **pip**:
+There are several ways to install and use django-upgrade, here are two common scenarios.
+
+
+Option 1: pip
+-------------
+
+Install the ``django-upgrade`` command with pip. See **Usage** for an introduction to the ``django-upgrade`` command.
 
 .. code-block:: sh
 
     python -m pip install django-upgrade
 
-Python 3.8 to 3.11 supported. See **Usage** for an introduction to the ``django-upgrade`` command.
+Python 3.8 to 3.11 supported.
 
-**Option 2**: Install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook. Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
+
+Option 2: pre-commit
+--------------------
+
+You can install django-upgrade as a `pre-commit <https://pre-commit.com/>`__ hook. Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` file (`docs <https://pre-commit.com/#plugins>`__):
 
 .. code-block:: yaml
 
@@ -48,9 +58,11 @@ To upgrade your entire project immediately, you can tell pre-commit to run the `
 
     pre-commit run django-upgrade --all-files
 
-.. tip:: Leaving this hook in place after the upgrade process is considered entirely safe and actually recommended! Django-upgrade may receive future improvements and thus keep improving your code.
+----
 
-.. tip:: Normally, pre-commit will run exactly on the files that you have changed in your commit. Pre-commit can also help you update to the latest ``django-upgrade`` version with its ``autoupdate`` command. This is a sufficient flow for most cases, but remember to also run ``pre-commit run django-upgrade --all-files`` as django-upgrade may add new improvements in each release.
+**Tip:** Leaving this hook in place after the upgrade process is considered entirely safe and actually recommended! Django-upgrade may receive future improvements and thus keep improving your code.
+
+**Tip:** Pre-commit can help you update to the latest ``django-upgrade`` version with its ``autoupdate`` command. Normally, pre-commit will run exactly on the files that you have changed in your commit. This is a sufficient flow for most cases, but remember to also run ``pre-commit run django-upgrade --all-files`` as django-upgrade may add new improvements in each release.
 
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ Python 3.8 to 3.11 supported. See **Usage** for an introduction to the ``django-
         hooks:
         -   id: django-upgrade
             args: [--target-version, "4.1"]   # Replace with Django version
+            types: [file, python]
 
 To upgrade your entire project immediately, you can tell pre-commit to run the ``django-upgrade`` hook on all files. Once you commit these changes, your other pre-commit linters will execute and you may see further changes. Use the following command:
 


### PR DESCRIPTION
I was reading the installation / usage and initially got a bit confused on which approach to choose and why.

This PR adds:

1. A more clear distinction between CLI and pre-commit usage
2. I also added some tips to clarify that it's not a pre-commit hook that one is supposed to simply remove again after the upgrade process
3. ~pre-commit configuration now says which file types to operate on (however, maybe that could/should be added in this repo's hook specification instead?)~ this is already defined in the hook definition, so no need!