### PR TITLE
Remove domain_allowlist fix for EmailValidator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -685,7 +685,7 @@ This only applies in command files, which are heuristically detected as files wi
 ``EmailValidator``
 ~~~~~~~~~~~~~~~~~~
 
-Rewrites keyword arguments to their new names: ``whitelist`` to ``allowlist``, and ``domain_whitelist`` to ``domain_allowlist``.
+Rewrites keyword arguments to their new names: ``whitelist`` to ``allowlist``.
 
 .. code-block:: diff
 
@@ -693,8 +693,6 @@ Rewrites keyword arguments to their new names: ``whitelist`` to ``allowlist``, a
 
     -EmailValidator(whitelist=["example.com"])
     +EmailValidator(allowlist=["example.com"])
-    -EmailValidator(domain_whitelist=["example.org"])
-    +EmailValidator(domain_allowlist=["example.org"])
 
 ``default_app_config``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/django_upgrade/fixers/email_validator.py
+++ b/src/django_upgrade/fixers/email_validator.py
@@ -21,10 +21,7 @@ fixer = Fixer(
 
 MODULE = "django.core.validators"
 NAME = "EmailValidator"
-KWARGS = {
-    "whitelist": "allowlist",
-    "domain_whitelist": "domain_allowlist",
-}
+KWARGS = {"whitelist": "allowlist"}
 
 
 @fixer.register(ast.Call)

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -368,7 +368,6 @@ def replace_argument_names(
 
     for n, keyword in reversed(list(enumerate(node.keywords))):
         if keyword.arg in arg_map:
-            x, y = kwarg_func_args[n]
             for k in range(*kwarg_func_args[n]):
                 if tokens[k].src == keyword.arg:
                     tokens[k] = tokens[k]._replace(src=arg_map[keyword.arg])

--- a/tests/fixers/test_email_validator.py
+++ b/tests/fixers/test_email_validator.py
@@ -40,54 +40,20 @@ def test_whitelist():
     )
 
 
-def test_domain_whitelist():
-    check_transformed(
-        """\
-        from django.core.validators import EmailValidator
-        EmailValidator(domain_whitelist=["example.com"])
-        """,
-        """\
-        from django.core.validators import EmailValidator
-        EmailValidator(domain_allowlist=["example.com"])
-        """,
-        settings,
-    )
-
-
-def test_both_module_imported():
-    check_transformed(
-        """\
-        from django.core import validators
-        validators.EmailValidator(
-            "hi", code="abc",
-            whitelist=["example.com"], domain_whitelist=["example.org"]
-        )
-        """,
-        """\
-        from django.core import validators
-        validators.EmailValidator(
-            "hi", code="abc",
-            allowlist=["example.com"], domain_allowlist=["example.org"]
-        )
-        """,
-        settings,
-    )
-
-
-def test_both_and_other_args():
+def test_other_args():
     check_transformed(
         """\
         from django.core.validators import EmailValidator
         EmailValidator(
             "hi", code="abc",
-            whitelist=["example.com"], domain_whitelist=["example.org"]
+            whitelist=["example.com"],
         )
         """,
         """\
         from django.core.validators import EmailValidator
         EmailValidator(
             "hi", code="abc",
-            allowlist=["example.com"], domain_allowlist=["example.org"]
+            allowlist=["example.com"],
         )
         """,
         settings,


### PR DESCRIPTION
While working on the `ModelMultipleChoiceField` fixer, I noticed that the `EmailValidator` was allowed to rewrite `domain_whitelist` kwarg to `domain_allowlist` however this is not a valid kwarg for an `EmailValidator`.

This is only an undocumented attribute to the `EmailValidator` class. From the docs:

> The whitelist parameter is deprecated. Use [allowlist](https://docs.djangoproject.com/en/4.0/ref/validators/#django.core.validators.EmailValidator.allowlist) instead. The undocumented domain_whitelist attribute is deprecated. Use domain_allowlist instead.

This PR simply remove the `domain_whitelist` fix and update the docs.