### PR TITLE
Preserve double quotes when rewriting string tokens

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,6 +42,10 @@ History
 
   Thanks to Benjamin Bach for the report in `Issue #250 <https://github.com/adamchainz/django-upgrade/issues/250>`__, and to Thibaut Decombe for the fix in `PR #270 <https://github.com/adamchainz/django-upgrade/pull/270>`__.
 
+* Fixers that modify string literals now match existing use of double quotes.
+
+  Thanks to Kevin Marsh in `PR #260 <https://github.com/adamchainz/django-upgrade/pull/260>`__.
+
 * Make fixers that erase lines also erase any trailing comments.
 
 * Fix leaving a trailing comma when editing imports in certain cases.

--- a/src/django_upgrade/fixers/django_urls.py
+++ b/src/django_upgrade/fixers/django_urls.py
@@ -22,6 +22,7 @@ from django_upgrade.tokens import (
     insert,
     replace,
     update_import_names,
+    uses_double_quotes,
 )
 
 fixer = Fixer(
@@ -171,7 +172,11 @@ def fix_url_call(
         path = convert_path_syntax(regex_path)
         if path is not None:
             string_idx = find(tokens, i, name=STRING)
-            replace(tokens, string_idx, src=repr(path))
+            if uses_double_quotes(tokens[string_idx].src):
+                path = f'"{path}"'
+            else:
+                path = f"'{path}'"
+            replace(tokens, string_idx, src=path)
             new_name = "path"
     if new_name != node_name:
         state_added_names.setdefault(state, set()).add(new_name)

--- a/src/django_upgrade/fixers/django_urls.py
+++ b/src/django_upgrade/fixers/django_urls.py
@@ -21,8 +21,8 @@ from django_upgrade.tokens import (
     find,
     insert,
     replace,
+    str_repr_matching,
     update_import_names,
-    uses_double_quotes,
 )
 
 fixer = Fixer(
@@ -172,10 +172,7 @@ def fix_url_call(
         path = convert_path_syntax(regex_path)
         if path is not None:
             string_idx = find(tokens, i, name=STRING)
-            if uses_double_quotes(tokens[string_idx].src):
-                path = f'"{path}"'
-            else:
-                path = f"'{path}'"
+            path = str_repr_matching(path, match_quotes=tokens[string_idx].src)
             replace(tokens, string_idx, src=path)
             new_name = "path"
     if new_name != node_name:

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -13,7 +13,7 @@ from tokenize_rt import Offset, Token
 
 from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import NAME, STRING, find, replace, uses_double_quotes
+from django_upgrade.tokens import NAME, STRING, find, replace, str_repr_matching
 
 fixer = Fixer(
     __name__,
@@ -129,18 +129,12 @@ def rewrite_header_access(tokens: list[Token], i: int, *, header_name: str) -> N
     meta_idx = find(tokens, i, name=NAME, src="META")
     replace(tokens, meta_idx, src="headers")
     str_idx = find(tokens, meta_idx, name=STRING)
-    if uses_double_quotes(tokens[str_idx].src):
-        header_name = f'"{header_name}"'
-    else:
-        header_name = f"'{header_name}'"
-    replace(tokens, str_idx, src=header_name)
+    header_src = str_repr_matching(header_name, match_quotes=tokens[str_idx].src)
+    replace(tokens, str_idx, src=header_src)
 
 
 def rewrite_in_statement(tokens: list[Token], i: int, *, header_name: str) -> None:
-    if uses_double_quotes(tokens[i].src):
-        header_name = f'"{header_name}"'
-    else:
-        header_name = f"'{header_name}'"
-    replace(tokens, i, src=header_name)
+    header_src = str_repr_matching(header_name, match_quotes=tokens[i].src)
+    replace(tokens, i, src=header_src)
     meta_idx = find(tokens, i, name=NAME, src="META")
     replace(tokens, meta_idx, src="headers")

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -13,7 +13,7 @@ from tokenize_rt import Offset, Token
 
 from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import NAME, STRING, find, replace
+from django_upgrade.tokens import NAME, STRING, find, replace, uses_double_quotes
 
 fixer = Fixer(
     __name__,
@@ -129,10 +129,18 @@ def rewrite_header_access(tokens: list[Token], i: int, *, header_name: str) -> N
     meta_idx = find(tokens, i, name=NAME, src="META")
     replace(tokens, meta_idx, src="headers")
     str_idx = find(tokens, meta_idx, name=STRING)
-    replace(tokens, str_idx, src=repr(header_name))
+    if uses_double_quotes(tokens[str_idx].src):
+        header_name = f'"{header_name}"'
+    else:
+        header_name = f"'{header_name}'"
+    replace(tokens, str_idx, src=header_name)
 
 
 def rewrite_in_statement(tokens: list[Token], i: int, *, header_name: str) -> None:
-    replace(tokens, i, src=repr(header_name))
+    if uses_double_quotes(tokens[i].src):
+        header_name = f'"{header_name}"'
+    else:
+        header_name = f"'{header_name}'"
+    replace(tokens, i, src=header_name)
     meta_idx = find(tokens, i, name=NAME, src="META")
     replace(tokens, meta_idx, src="headers")

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import re
 from collections import defaultdict
 
 from tokenize_rt import NON_CODING_TOKENS, UNIMPORTANT_WS, Token, tokens_to_src
@@ -478,3 +479,13 @@ def update_import_modules(
     for module, names in reversed(imports_to_add.items()):
         joined_names = ", ".join(sorted(names))
         insert(tokens, j, new_src=f"{indent}from {module} import {joined_names}\n")
+
+
+double_quote_string_re = re.compile(r'^[bfru]*".*"$', flags=re.IGNORECASE)
+
+
+def uses_double_quotes(src: str) -> bool:
+    """
+    Return whether a string token's src uses double quotes.
+    """
+    return double_quote_string_re.match(src) is not None

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -377,6 +377,27 @@ def replace_argument_names(
                 raise AssertionError(f"{keyword.arg} argument not found")
 
 
+str_repr_single_to_double = str.maketrans(
+    {
+        "'": '"',
+        '"': '\\"',
+    }
+)
+
+
+def str_repr_matching(text: str, *, match_quotes: str) -> str:
+    """
+    Give the repr of a string, switching it to double quotes if the string
+    literal represent in match_quotes uses double quotes.
+    """
+    result = repr(text)
+    first_quote = re.search(r'[\'"]', match_quotes)
+    assert first_quote is not None
+    if first_quote[0] == '"' and result[0] != '"':
+        result = result.translate(str_repr_single_to_double)
+    return result
+
+
 def update_import_names(
     tokens: list[Token],
     i: int,
@@ -479,13 +500,3 @@ def update_import_modules(
     for module, names in reversed(imports_to_add.items()):
         joined_names = ", ".join(sorted(names))
         insert(tokens, j, new_src=f"{indent}from {module} import {joined_names}\n")
-
-
-double_quote_string_re = re.compile(r'^[bfru]*".*"$', flags=re.IGNORECASE)
-
-
-def uses_double_quotes(src: str) -> bool:
-    """
-    Return whether a string token's src uses double quotes.
-    """
-    return double_quote_string_re.match(src) is not None

--- a/tests/fixers/test_django_urls.py
+++ b/tests/fixers/test_django_urls.py
@@ -217,12 +217,28 @@ def test_path_empty():
         """\
         from django.conf.urls import url
 
-        url(r"^$", views.index)
+        url(r'^$', views.index)
         """,
         """\
         from django.urls import path
 
         path('', views.index)
+        """,
+        settings,
+    )
+
+
+def test_path_empty_double_quoted():
+    check_transformed(
+        """\
+        from django.conf.urls import url
+
+        url(r"^$", views.index)
+        """,
+        """\
+        from django.urls import path
+
+        path("", views.index)
         """,
         settings,
     )
@@ -303,6 +319,22 @@ def test_path_int_converter_1():
         from django.urls import path
 
         path('page/<int:number>/', views.page)
+        """,
+        settings,
+    )
+
+
+def test_path_int_converter_1_double_quotes():
+    check_transformed(
+        """\
+        from django.conf.urls import url
+
+        url(r"^page/(?P<number>[0-9]+)/$", views.page)
+        """,
+        """\
+        from django.urls import path
+
+        path("page/<int:number>/", views.page)
         """,
         settings,
     )
@@ -422,7 +454,7 @@ def test_re_path_empty():
         """\
         from django.urls import re_path
 
-        re_path(r"^$", views.index)
+        re_path(r'^$', views.index)
         """,
         """\
         from django.urls import path
@@ -715,7 +747,7 @@ def test_combined_5():
         from django.urls import re_path
 
         include('example.urls')
-        re_path(r"^$", views.index)
+        re_path(r'^$', views.index)
         """,
         """\
         from django.urls import include, path

--- a/tests/fixers/test_request_headers.py
+++ b/tests/fixers/test_request_headers.py
@@ -69,7 +69,7 @@ def test_subscript_simple_double_quotes():
         request.META["HTTP_SERVER"]
         """,
         """\
-        request.headers["Server"]
+        request.headers["server"]
         """,
         settings,
     )
@@ -189,7 +189,7 @@ def test_in_double_quotes():
         "HTTP_AUTHORIZATION" in request.META
         """,
         """\
-        "Authorization" in request.headers
+        "authorization" in request.headers
         """,
         settings,
     )

--- a/tests/fixers/test_request_headers.py
+++ b/tests/fixers/test_request_headers.py
@@ -63,6 +63,18 @@ def test_subscript_simple():
     )
 
 
+def test_subscript_simple_double_quotes():
+    check_transformed(
+        """\
+        request.META["HTTP_SERVER"]
+        """,
+        """\
+        request.headers["Server"]
+        """,
+        settings,
+    )
+
+
 def test_subscript_two_words():
     check_transformed(
         """\
@@ -166,6 +178,18 @@ def test_in():
         """,
         """\
         'authorization' in request.headers
+        """,
+        settings,
+    )
+
+
+def test_in_double_quotes():
+    check_transformed(
+        """\
+        "HTTP_AUTHORIZATION" in request.META
+        """,
+        """\
+        "Authorization" in request.headers
         """,
         settings,
     )

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import ast
 
+import pytest
 from tokenize_rt import Token, src_to_tokens, tokens_to_src
 
-from django_upgrade.tokens import update_import_names
+from django_upgrade.tokens import update_import_names, uses_double_quotes
 
 
 def tokenize_and_parse(source: str) -> tuple[list[Token], ast.Module]:
@@ -104,3 +105,35 @@ class TestUpdateImportNames:
             name_map={"b": "", "c": ""},
             after="from a import d",
         )
+
+
+@pytest.mark.parametrize(
+    "string",
+    (
+        '""',
+        'r""',
+        '"foo"',
+        'r"foo"',
+        'R"foo"',
+        'rf"foo{bar}"',
+    ),
+)
+def test_are_double_quoted(string):
+    assert uses_double_quotes(string)
+
+
+@pytest.mark.parametrize(
+    "string",
+    (
+        "",
+        "foo",
+        "''",
+        "r''",
+        "'foo'",
+        "r'foo'",
+        "R'foo'",
+        "rf'foo{bar}'",
+    ),
+)
+def test_are_not_double_quoted(string):
+    assert not uses_double_quotes(string)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -8,6 +8,21 @@ from tokenize_rt import Token, src_to_tokens, tokens_to_src
 from django_upgrade.tokens import str_repr_matching, update_import_names
 
 
+@pytest.mark.parametrize(
+    "text,match_quotes,expected",
+    (
+        ("ball", "'bat'", "'ball'"),
+        ("ball", '"bat"', '"ball"'),
+        ("ball", 'r"bat"', '"ball"'),
+        ("quote: 'hi'", "'bat'", "\"quote: 'hi'\""),
+        ('quote: "hi"', "'bat'", "'quote: \"hi\"'"),
+        ('quote: "hi"', '"bat"', '"quote: \\"hi\\""'),
+    ),
+)
+def test_str_repr_matching(text, match_quotes, expected):
+    assert str_repr_matching(text, match_quotes=match_quotes) == expected
+
+
 def tokenize_and_parse(source: str) -> tuple[list[Token], ast.Module]:
     return src_to_tokens(source), ast.parse(source)
 
@@ -105,18 +120,3 @@ class TestUpdateImportNames:
             name_map={"b": "", "c": ""},
             after="from a import d",
         )
-
-
-@pytest.mark.parametrize(
-    "text,match_quotes,expected",
-    (
-        ("ball", "'bat'", "'ball'"),
-        ("ball", '"bat"', '"ball"'),
-        ("ball", 'r"bat"', '"ball"'),
-        ("quote: 'hi'", "'bat'", "\"quote: 'hi'\""),
-        ('quote: "hi"', "'bat'", "'quote: \"hi\"'"),
-        ('quote: "hi"', '"bat"', '"quote: \\"hi\\""'),
-    ),
-)
-def test_str_repr_matching(text, match_quotes, expected):
-    assert str_repr_matching(text, match_quotes=match_quotes) == expected

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -5,7 +5,7 @@ import ast
 import pytest
 from tokenize_rt import Token, src_to_tokens, tokens_to_src
 
-from django_upgrade.tokens import update_import_names, uses_double_quotes
+from django_upgrade.tokens import str_repr_matching, update_import_names
 
 
 def tokenize_and_parse(source: str) -> tuple[list[Token], ast.Module]:
@@ -108,32 +108,15 @@ class TestUpdateImportNames:
 
 
 @pytest.mark.parametrize(
-    "string",
+    "text,match_quotes,expected",
     (
-        '""',
-        'r""',
-        '"foo"',
-        'r"foo"',
-        'R"foo"',
-        'rf"foo{bar}"',
+        ("ball", "'bat'", "'ball'"),
+        ("ball", '"bat"', '"ball"'),
+        ("ball", 'r"bat"', '"ball"'),
+        ("quote: 'hi'", "'bat'", "\"quote: 'hi'\""),
+        ('quote: "hi"', "'bat'", "'quote: \"hi\"'"),
+        ('quote: "hi"', '"bat"', '"quote: \\"hi\\""'),
     ),
 )
-def test_are_double_quoted(string):
-    assert uses_double_quotes(string)
-
-
-@pytest.mark.parametrize(
-    "string",
-    (
-        "",
-        "foo",
-        "''",
-        "r''",
-        "'foo'",
-        "r'foo'",
-        "R'foo'",
-        "rf'foo{bar}'",
-    ),
-)
-def test_are_not_double_quoted(string):
-    assert not uses_double_quotes(string)
+def test_str_repr_matching(text, match_quotes, expected):
+    assert str_repr_matching(text, match_quotes=match_quotes) == expected


### PR DESCRIPTION
I was attempting to use `django-upgrade` on a project which prefers double quotes over single quotes, meaning when something was rewritten like:
```diff
-request.META["HTTP_SERVER"]
+request.headers['Server']
```
it's linter would complain that it's expecting double quotes.

I'm not sure this solution is fully comprehensive but wanted to get feedback before spending any more time on it, but hopefully it's not too controversial to keep the existing quote style during rewrites.