### PR TITLE
Preserve tab indentation when rewriting decorators

### DIFF
--- a/src/django_upgrade/fixers/admin_decorators.py
+++ b/src/django_upgrade/fixers/admin_decorators.py
@@ -168,6 +168,7 @@ def decorate_function(
     if decorated:
         i = reverse_find(tokens, i, name=OP, src="@")
     j, indent = extract_indent(tokens, i)
+    default_indent = indent if indent else "    "
     dec_src = f"{indent}@admin.{funcdetails.decorator}(\n"
 
     # Pull args in predefined order
@@ -179,8 +180,8 @@ def decorate_function(
     ]
     comma = "," if len(args) > 1 else ""
     for name, source in args:
-        source = source.replace("\n", f"\n{indent}    ")
-        dec_src += f"{indent}    {name}={source}{comma}\n"
+        source = source.replace("\n", f"\n{indent}{default_indent}")
+        dec_src += f"{indent}{default_indent}{name}={source}{comma}\n"
     dec_src += f"{indent})\n"
     insert(tokens, j, new_src=dec_src)
 

--- a/tests/fixers/test_admin_decorators.py
+++ b/tests/fixers/test_admin_decorators.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from django_upgrade.data import Settings
 from tests.fixers.tools import check_noop, check_transformed
 
@@ -147,6 +149,30 @@ class TestActionFunctions:
             )
             def make_published(modeladmin, request, queryset):
                 ...
+
+            """,
+            settings,
+        )
+
+    @pytest.mark.xfail(reason="Currently only look at current line's indentation")
+    def test_module_permissions_indented_with_tabs(self):
+        check_transformed(
+            """\
+            from django.contrib import admin
+
+            def make_published(modeladmin, request, queryset):
+            	...
+
+            make_published.allowed_permissions = ('change',)
+            """,
+            """\
+            from django.contrib import admin
+
+            @admin.action(
+            	permissions=('change',)
+            )
+            def make_published(modeladmin, request, queryset):
+            	...
 
             """,
             settings,
@@ -315,6 +341,31 @@ class TestActionFunctions:
                 )
                 def make_published(self, request, queryset):
                     ...
+
+            """,
+            settings,
+        )
+
+    def test_class_description_indented_with_tabs(self):
+        check_transformed(
+            """\
+            from django.contrib import admin
+
+            class BookAdmin(admin.ModelAdmin):
+            	def make_published(self, request, queryset):
+            		...
+
+            	make_published.short_description = "yada"
+            """,
+            """\
+            from django.contrib import admin
+
+            class BookAdmin(admin.ModelAdmin):
+            	@admin.action(
+            		description="yada"
+            	)
+            	def make_published(self, request, queryset):
+            		...
 
             """,
             settings,


### PR DESCRIPTION
Similar to #260, if a project also prefers tabs over spaces, currently `django-upgrade` will transform
![2022-09-30_12-51](https://user-images.githubusercontent.com/1423728/193346149-2fd84583-1cab-4555-b5bb-7cb87e541bc6.png)

into this containing tabs and spaces:
![2022-09-30_12-51_1](https://user-images.githubusercontent.com/1423728/193346178-8e825379-2f75-4c07-94e2-7229f57b08a4.png)

This is simple enough to resolve when the line being re-writtnen already contains tabs (see passing test) but would require a larger refactor for lines that aren't indented (see `xfail`-ing test). Am leaving as a draft but could be merged as a partial fix, or just closed as a "don't want to go down this rabbit hole"