### PR TITLE
Fix urls fixer wrong import rewrite

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,10 @@ History
 
 * Update ``timezone.utc`` fixer to only use absolute references from existing imports of the ``datetime`` module.
 
+* Make Django 2.0+ URL fixer avoid a loop of adding imports that already exist.
+
+  Thanks to Benjamin Bach for the report in `Issue #250 <https://github.com/adamchainz/django-upgrade/issues/250>`__, and to Thibaut Decombe for the fix in `PR #270 <https://github.com/adamchainz/django-upgrade/pull/270>`__.
+
 * Make fixers that erase lines also erase any trailing comments.
 
 * Fix leaving a trailing comma when editing imports in certain cases.

--- a/src/django_upgrade/fixers/django_urls.py
+++ b/src/django_upgrade/fixers/django_urls.py
@@ -140,7 +140,7 @@ def visit_Call(
                 and "url" in state.from_imports["django.conf.urls"]
             )
             or (
-                ((node_name := node.func.id) == "re_path")
+                (node_name := node.func.id) == "re_path"
                 and "re_path" in state.from_imports["django.urls"]
             )
         )

--- a/src/django_upgrade/fixers/django_urls.py
+++ b/src/django_upgrade/fixers/django_urls.py
@@ -58,9 +58,9 @@ def visit_ImportFrom(
         )
 
 
-# Track which of path and re_path have been used for this current file
-# Then when backtracking into an import statement, we can use the set of names
-# to determine what names to import.
+# Track if re_path has been used, and which names need adding.
+# When fixing import statements, these variables determine which names to
+# import/remove.
 state_re_path_used: MutableMapping[State, bool] = WeakKeyDictionary()
 state_added_names: MutableMapping[State, set[str]] = WeakKeyDictionary()
 

--- a/tests/fixers/test_django_urls.py
+++ b/tests/fixers/test_django_urls.py
@@ -473,7 +473,8 @@ def test_re_path_multiple_import():
         re_path(r'^more-info/$', views.more_info)
         """,
         """\
-        from django.urls import path, reverse
+        from django.urls import path
+        from django.urls import reverse
 
         path('more-info/', views.more_info)
         """,
@@ -592,7 +593,8 @@ def test_re_path_complete():
         ]
         """,
         """\
-        from django.urls import include, path, re_path
+        from django.urls import path
+        from django.urls import include, re_path
 
         urlpatterns = [
             path('', views.index, name='index'),
@@ -619,7 +621,8 @@ def test_combined_keep_re_path():
         ]
         """,
         """\
-        from django.urls import include, path, re_path, reverse
+        from django.urls import include, path
+        from django.urls import re_path, reverse
 
         urlpatterns = [
             path('', views.index, name='index'),
@@ -643,7 +646,8 @@ def test_combined_rewrite_all():
         ]
         """,
         """\
-        from django.urls import include, path, reverse
+        from django.urls import include, path
+        from django.urls import reverse
 
         urlpatterns = [
             path('', views.index, name='index'),
@@ -667,7 +671,8 @@ def test_combined_3():
         ]
         """,
         """\
-        from django.urls import include, path, re_path, reverse
+        from django.urls import include, path
+        from django.urls import re_path, reverse
 
         urlpatterns = [
             path('', views.index, name='index'),
@@ -690,7 +695,8 @@ def test_combined_4():
         ]
         """,
         """\
-        from django.urls import include, path, reverse
+        from django.urls import include, path
+        from django.urls import reverse
 
         urlpatterns = [
             path('', views.index, name='index'),
@@ -716,6 +722,19 @@ def test_combined_5():
 
         include('example.urls')
         path('', views.index)
+        """,
+        settings,
+    )
+
+
+def test_two_imported_used():
+    check_noop(
+        """\
+        from django.urls import path
+        from django.urls import re_path
+
+        path('whatever')
+        re_path('whatever')
         """,
         settings,
     )


### PR DESCRIPTION
My attempt to fix #250.

I noticed that the underlying issue is that some noop tests are actually doing rewrites.

For exemple, the following is actually triggering an erase/rewrite of the import node but since it rewrites the same thing we don't notice it:

```python
def test_fake_noop():
    check_noop(
        """\
        from django.urls import re_path

        re_path('whatever')
        """,
        settings,
    )
```

I added a `state_added_names` variable to keep track of names that will need to be imported. Then I can only add an import with these names (minus the ones initially imported). 

PS: Last commit replace the `state_used_names` variable with `state_re_path_used` because it was only needed to determine if the `re_path` import can be removed.

I'm unsure if it's the best way to deal with this so I'm happy to take any feed back. At least maybe this will give you some food for thoughts on your attempt.

Cheers