### PR TITLE
Make `re_path` fixer convert more `include()`s

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,12 @@
 History
 =======
 
+* Make ``re_path`` -> ``path`` fixer also convert ``include()``'s with unterminated regexes.
+
+  Thanks to Thibaut Decombe in `PR #279 <https://github.com/adamchainz/django-upgrade/pull/279>`__.
+
 * Avoid rewriting ``request.META`` to ``request.headers`` in ``del`` statements.
-  This pattern works for ``request.META`` but not for ``request.headers`` which is an immutable Mapping.
+  This pattern works for ``request.META`` but not for ``request.headers`` which is an immutable mapping.
 
   Thanks to Thibaut Decombe in `PR #290 <https://github.com/adamchainz/django-upgrade/pull/290>`__.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 History
 =======
 
-* Make ``re_path`` -> ``path`` fixer also convert ``include()``'s with unterminated regexes.
+* Make ``re_path`` -> ``path`` fixer also convert ``include()``\'s with unterminated regexes.
 
   Thanks to Thibaut Decombe in `PR #279 <https://github.com/adamchainz/django-upgrade/pull/279>`__.
 

--- a/src/django_upgrade/compat.py
+++ b/src/django_upgrade/compat.py
@@ -4,10 +4,18 @@ import sys
 
 if sys.version_info >= (3, 9):
     str_removeprefix = str.removeprefix
+    str_removesuffix = str.removesuffix
 else:
 
     def str_removeprefix(self: str, prefix: str, /) -> str:  # pragma: no cover
         if self.startswith(prefix):
             return self[len(prefix) :]
+        else:
+            return self[:]
+
+    def str_removesuffix(self: str, suffix: str, /) -> str:
+        # suffix='' should not call self[:-0].
+        if suffix and self.endswith(suffix):
+            return self[: -len(suffix)]
         else:
             return self[:]

--- a/src/django_upgrade/fixers/django_urls.py
+++ b/src/django_upgrade/fixers/django_urls.py
@@ -17,6 +17,7 @@ from tokenize_rt import Token
 from django_upgrade.ast import ast_start_offset
 from django_upgrade.ast import is_rewritable_import_from
 from django_upgrade.compat import str_removeprefix
+from django_upgrade.compat import str_removesuffix
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
@@ -157,9 +158,20 @@ def visit_Call(
             ):
                 regex_path = node.args[0].value
 
-            yield ast_start_offset(node), partial(
-                fix_url_call, regex_path=regex_path, state=state, node_name=node_name
+            include_called = (
+                len(node.args) >= 2
+                and isinstance(node.args[1], ast.Call)
+                and isinstance(node.args[1].func, ast.Name)
+                and node.args[1].func.id == "include"
             )
+            yield ast_start_offset(node), partial(
+                fix_url_call,
+                regex_path=regex_path,
+                state=state,
+                node_name=node_name,
+                include_called=include_called,
+            )
+
         elif (
             node.func.id == "include"
             and "include" in state.from_imports["django.conf.urls"]
@@ -168,11 +180,17 @@ def visit_Call(
 
 
 def fix_url_call(
-    tokens: list[Token], i: int, *, regex_path: str | None, state: State, node_name: str
+    tokens: list[Token],
+    i: int,
+    *,
+    regex_path: str | None,
+    state: State,
+    node_name: str,
+    include_called: bool,
 ) -> None:
     new_name = "re_path"
     if regex_path is not None:
-        path = convert_path_syntax(regex_path)
+        path = convert_path_syntax(regex_path, include_called)
         if path is not None:
             string_idx = find(tokens, i, name=STRING)
             path = str_repr_matching(path, match_quotes=tokens[string_idx].src)
@@ -195,10 +213,11 @@ REGEX_TO_CONVERTER = {
 }
 
 
-def convert_path_syntax(regex_path: str) -> str | None:
-    if not regex_path.endswith("$"):
+def convert_path_syntax(regex_path: str, include_called: bool) -> str | None:
+    if not regex_path.endswith("$") and not include_called:
         return None
-    remaining = str_removeprefix(regex_path[:-1], "^")
+    remaining = str_removeprefix(regex_path, "^")
+    remaining = str_removesuffix(remaining, "$")
     path = ""
     while "(?P<" in remaining:
         prefix, rest = remaining.split("(?P<", 1)

--- a/src/django_upgrade/fixers/django_urls.py
+++ b/src/django_upgrade/fixers/django_urls.py
@@ -214,7 +214,7 @@ REGEX_TO_CONVERTER = {
 
 
 def convert_path_syntax(regex_path: str, include_called: bool) -> str | None:
-    if not regex_path.endswith("$") and not include_called:
+    if not (regex_path.endswith("$") or include_called):
         return None
     remaining = str_removeprefix(regex_path, "^")
     remaining = str_removesuffix(remaining, "$")

--- a/tests/fixers/test_django_urls.py
+++ b/tests/fixers/test_django_urls.py
@@ -218,13 +218,13 @@ def test_re_path_unanchored_end_with_include():
         """\
         from django.urls import re_path, include
 
-        re_path(r'^accounts/$', include('allauth.urls')),
+        re_path(r'^accounts/$', include('allauth.urls'))
         """,
         """\
         from django.urls import path
         from django.urls import include
 
-        path('accounts/', include('allauth.urls')),
+        path('accounts/', include('allauth.urls'))
         """,
         settings,
     )
@@ -235,12 +235,12 @@ def test_url_unanchored_end_with_include():
         """\
         from django.conf.urls import url, include
 
-        url(r'^accounts/', include('allauth.urls')),
+        url(r'^accounts/', include('allauth.urls'))
         """,
         """\
         from django.urls import include, path
 
-        path('accounts/', include('allauth.urls')),
+        path('accounts/', include('allauth.urls'))
         """,
         settings,
     )
@@ -476,7 +476,7 @@ def test_complete():
             path('about/', views.about, name='about'),
             path('post/<slug:slug>/', views.post, name='post'),
             re_path(r'^post/(?P<slug>[\\w-]+)/$', views.post, name='post'),
-            re_path(r'^weblog/', include('blog.urls')),
+            path('weblog/', include('blog.urls')),
         ]
         """,
         settings,
@@ -654,8 +654,8 @@ def test_re_path_complete():
             re_path(r'^$', views.index, name='index'),
             re_path(r'^about/$', views.about, name='about'),
             re_path(r'^post/(?P<slug>[-a-zA-Z0-9_]+)/$', views.post, name='post'),
-            re_path(r'^post/(?P<year>[0-9]{4})/$', views.post, name='post'),
             re_path(r'^weblog/', include('blog.urls')),
+            re_path(r'^post/(?P<year>[0-9]{4})/$', views.post, name='post'),
         ]
         """,
         """\
@@ -666,8 +666,8 @@ def test_re_path_complete():
             path('', views.index, name='index'),
             path('about/', views.about, name='about'),
             path('post/<slug:slug>/', views.post, name='post'),
+            path('weblog/', include('blog.urls')),
             re_path(r'^post/(?P<year>[0-9]{4})/$', views.post, name='post'),
-            re_path(r'^weblog/', include('blog.urls')),
         ]
         """,
         settings,
@@ -683,7 +683,7 @@ def test_combined_keep_re_path():
 
         urlpatterns = [
             re_path(r'^$', views.index, name='index'),
-            re_path(r'^weblog/', include('blog.urls')),
+            re_path(r'^weblog/[0-9]{4}', include('blog.urls')),
         ]
         """,
         """\
@@ -692,7 +692,7 @@ def test_combined_keep_re_path():
 
         urlpatterns = [
             path('', views.index, name='index'),
-            re_path(r'^weblog/', include('blog.urls')),
+            re_path(r'^weblog/[0-9]{4}', include('blog.urls')),
         ]
         """,
         settings,
@@ -733,7 +733,7 @@ def test_combined_3():
 
         urlpatterns = [
             re_path(r'^$', views.index, name='index'),
-            re_path(r'^weblog/', include('blog.urls')),
+            re_path(r'^weblog/[0-9]{4}', include('blog.urls')),
         ]
         """,
         """\
@@ -742,7 +742,7 @@ def test_combined_3():
 
         urlpatterns = [
             path('', views.index, name='index'),
-            re_path(r'^weblog/', include('blog.urls')),
+            re_path(r'^weblog/[0-9]{4}', include('blog.urls')),
         ]
         """,
         settings,

--- a/tests/fixers/test_django_urls.py
+++ b/tests/fixers/test_django_urls.py
@@ -213,6 +213,39 @@ def test_re_path_unanchored_end():
     )
 
 
+def test_re_path_unanchored_end_with_include():
+    check_transformed(
+        """\
+        from django.urls import re_path, include
+
+        re_path(r'^accounts/$', include('allauth.urls')),
+        """,
+        """\
+        from django.urls import path
+        from django.urls import include
+
+        path('accounts/', include('allauth.urls')),
+        """,
+        settings,
+    )
+
+
+def test_url_unanchored_end_with_include():
+    check_transformed(
+        """\
+        from django.conf.urls import url, include
+
+        url(r'^accounts/', include('allauth.urls')),
+        """,
+        """\
+        from django.urls import include, path
+
+        path('accounts/', include('allauth.urls')),
+        """,
+        settings,
+    )
+
+
 def test_path_empty():
     check_transformed(
         """\


### PR DESCRIPTION
Fixes #263.

Now that the blocking issue is resolved, here is a patch! Let me know if you need me to make some adjustments.

_PS: I needed the `removesuffix` utility so I took the one from the [PEP 616](https://peps.python.org/pep-0616/#specification) similarly to what you probably did for the `removeprefix` one._