### PR TITLE
Use cross-platform regexes for some `State.looks_like*` functions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,10 @@ History
 
   Thanks to Thibaut Decombe in `PR #280 <https://github.com/adamchainz/django-upgrade/pull/280>`__.
 
+* Make detection of management commands and migration files detect both forward and backward slashes as directory separators.
+
+  Thanks to William Claassen in `PR #286 <https://github.com/adamchainz/django-upgrade/pull/286>`__.
+
 1.11.0 (2022-10-26)
 -------------------
 

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import os
 import pkgutil
 import re
 from collections import defaultdict
@@ -29,7 +28,9 @@ class Settings:
 
 
 admin_re = re.compile(r"(\b|_)admin(\b|_)")
+commands_re = re.compile(r"(^|[\\/])management[\\/]commands[\\/]")
 dunder_init_re = re.compile(r"(^|[\\/])__init__\.py$")
+migrations_re = re.compile(r"(^|[\\/])migrations([\\/])")
 settings_re = re.compile(r"(\b|_)settings(\b|_)")
 test_re = re.compile(r"(\b|_)tests?(\b|_)")
 
@@ -53,12 +54,7 @@ class State:
 
     @cached_property
     def looks_like_command_file(self) -> bool:
-        parts = self.filename.split(os.path.sep)
-        try:
-            i = parts.index("commands")
-        except ValueError:
-            return False
-        return i > 0 and i < (len(parts) - 1) and parts[i - 1] == "management"
+        return commands_re.search(self.filename) is not None
 
     @cached_property
     def looks_like_dunder_init_file(self) -> bool:
@@ -66,7 +62,7 @@ class State:
 
     @cached_property
     def looks_like_migrations_file(self) -> bool:
-        return "migrations" in self.filename.split(os.path.sep)
+        return migrations_re.search(self.filename) is not None
 
     @cached_property
     def looks_like_settings_file(self) -> bool:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -52,9 +52,13 @@ def test_looks_like_admin_file_false(filename: str) -> None:
     "filename",
     (
         "management/commands/test.py",
+        r"management\commands\test.py",
         "myapp/management/commands/test.py",
+        r"myapp\management\commands\test.py",
         "myapp/subapp/management/commands/test.py",
+        r"myapp\subapp\management\commands\test.py",
         "myapp/subapp/management/commands/test/subcommand.py",
+        r"myapp\subapp\management\commands\test\subcommand.py",
     ),
 )
 def test_looks_like_command_file_true(filename: str) -> None:
@@ -71,10 +75,15 @@ def test_looks_like_command_file_true(filename: str) -> None:
     (
         "test.py",
         "management/commands.py",
+        r"management\commands.py",
         "myapp/management/commands.py",
+        r"myapp\management\commands.py",
         "myapp/mgmt/commands.py",
+        r"myapp\mgmt\commands.py",
         "myapp/management/something/commands/example.py",
+        r"myapp\management\something\commands\example.py",
         "myapp/commands/management/example.py",
+        r"myapp\commands\management\example.py",
     ),
 )
 def test_looks_like_command_file_false(filename: str) -> None:
@@ -128,6 +137,79 @@ def test_looks_like_dunder_init_file_false(filename: str) -> None:
 @pytest.mark.parametrize(
     "filename",
     (
+        "project/migrations/0238_auto_20200424_1249.py",
+        r"project\migrations\0238_auto_20200424_1249.py",
+        "another_project/migrations/0001_initial.py",
+        r"another_project\migrations\0001_initial.py",
+    ),
+)
+def test_looks_like_migrations_file_true(filename: str) -> None:
+    state = State(
+        settings=settings,
+        filename=filename,
+        from_imports=defaultdict(set),
+    )
+    assert state.looks_like_migrations_file
+
+
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "0238_auto_20200424_1249.py",
+        "package/0001_initial.py",
+        r"package\0001_initial.py",
+        "migration/0001_initial.py",
+        r"migration\0001_initial.py",
+    ),
+)
+def test_looks_like_migrations_file_false(filename: str) -> None:
+    state = State(
+        settings=settings,
+        filename=filename,
+        from_imports=defaultdict(set),
+    )
+    assert not state.looks_like_migrations_file
+
+
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "settings.py",
+        "myapp/settings.py",
+        "myapp/settings/prod.py",
+        "myapp/prod_settings.py",
+        "myapp/local_settings.py",
+        "myapp/settings_tests.py",
+    ),
+)
+def test_looks_like_settings_file_true(filename: str) -> None:
+    state = State(
+        settings=settings,
+        filename=filename,
+        from_imports=defaultdict(set),
+    )
+    assert state.looks_like_settings_file
+
+
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "upsettings.py",
+        "settingsprod.py",
+    ),
+)
+def test_looks_like_settings_file_false(filename: str) -> None:
+    state = State(
+        settings=settings,
+        filename=filename,
+        from_imports=defaultdict(set),
+    )
+    assert not state.looks_like_settings_file
+
+
+@pytest.mark.parametrize(
+    "filename",
+    (
         "test_example.py",
         "example_test.py",
         "test.py",
@@ -166,39 +248,3 @@ def test_looks_like_test_file_false(filename: str) -> None:
         from_imports=defaultdict(set),
     )
     assert not state.looks_like_test_file
-
-
-@pytest.mark.parametrize(
-    "filename",
-    (
-        "settings.py",
-        "myapp/settings.py",
-        "myapp/settings/prod.py",
-        "myapp/prod_settings.py",
-        "myapp/local_settings.py",
-        "myapp/settings_tests.py",
-    ),
-)
-def test_looks_like_settings_file_true(filename: str) -> None:
-    state = State(
-        settings=settings,
-        filename=filename,
-        from_imports=defaultdict(set),
-    )
-    assert state.looks_like_settings_file
-
-
-@pytest.mark.parametrize(
-    "filename",
-    (
-        "upsettings.py",
-        "settingsprod.py",
-    ),
-)
-def test_looks_like_settings_file_false(filename: str) -> None:
-    state = State(
-        settings=settings,
-        filename=filename,
-        from_imports=defaultdict(set),
-    )
-    assert not state.looks_like_settings_file


### PR DESCRIPTION
Fixes #283
- `looks_like_migrations_file` and `looks_like_command_file` are converted to regex based filename checks.
- Tests for  `looks_like_migrations_file` added
- git example added for powershell to apply django-upgrade on multiple files