### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py38-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py38']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -6,18 +6,17 @@ import pkgutil
 import re
 from collections import defaultdict
 from functools import cached_property
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    DefaultDict,
-    Iterable,
-    List,
-    Tuple,
-    TypeVar,
-)
+from typing import Any
+from typing import Callable
+from typing import DefaultDict
+from typing import Iterable
+from typing import List
+from typing import Tuple
+from typing import TYPE_CHECKING
+from typing import TypeVar
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade import fixers
 

--- a/src/django_upgrade/fixers/admin_allow_tags.py
+++ b/src/django_upgrade/fixers/admin_allow_tags.py
@@ -12,7 +12,9 @@ from typing import Iterable
 from tokenize_rt import Offset
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import erase_node
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/admin_decorators.py
+++ b/src/django_upgrade/fixers/admin_decorators.py
@@ -8,20 +8,23 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import Iterable, Literal
+from typing import Iterable
+from typing import Literal
 
-from tokenize_rt import Offset, Token, tokens_to_src
+from tokenize_rt import Offset
+from tokenize_rt import Token
+from tokenize_rt import tokens_to_src
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    OP,
-    erase_node,
-    extract_indent,
-    find_last_token,
-    insert,
-    reverse_find,
-)
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import erase_node
+from django_upgrade.tokens import extract_indent
+from django_upgrade.tokens import find_last_token
+from django_upgrade.tokens import insert
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import reverse_find
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -6,14 +6,24 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import Iterable, Literal, MutableMapping, cast
+from typing import cast
+from typing import Iterable
+from typing import Literal
+from typing import MutableMapping
 from weakref import WeakKeyDictionary
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import OP, erase_node, extract_indent, insert, reverse_find
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import erase_node
+from django_upgrade.tokens import extract_indent
+from django_upgrade.tokens import insert
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import reverse_find
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/assert_form_error.py
+++ b/src/django_upgrade/fixers/assert_form_error.py
@@ -8,21 +8,26 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import Any, Iterable, Literal
+from typing import Any
+from typing import Iterable
+from typing import Literal
 
-from tokenize_rt import UNIMPORTANT_WS, Offset, Token, tokens_to_src
+from tokenize_rt import Offset
+from tokenize_rt import Token
+from tokenize_rt import tokens_to_src
+from tokenize_rt import UNIMPORTANT_WS
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    OP,
-    PHYSICAL_NEWLINE,
-    consume,
-    find_first_token,
-    find_last_token,
-    replace,
-    reverse_consume,
-)
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import consume
+from django_upgrade.tokens import find_first_token
+from django_upgrade.tokens import find_last_token
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import PHYSICAL_NEWLINE
+from django_upgrade.tokens import replace
+from django_upgrade.tokens import reverse_consume
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/compatibility_imports_1_11.py
+++ b/src/django_upgrade/fixers/compatibility_imports_1_11.py
@@ -10,8 +10,11 @@ from typing import Iterable
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import update_import_modules
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/compatibility_imports_1_9.py
+++ b/src/django_upgrade/fixers/compatibility_imports_1_9.py
@@ -10,8 +10,11 @@ from typing import Iterable
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import update_import_modules
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/crypto_get_random_string.py
+++ b/src/django_upgrade/fixers/crypto_get_random_string.py
@@ -8,11 +8,16 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import CODE, OP, find
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import CODE
+from django_upgrade.tokens import find
+from django_upgrade.tokens import OP
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/default_app_config.py
+++ b/src/django_upgrade/fixers/default_app_config.py
@@ -11,7 +11,9 @@ from typing import Iterable
 from tokenize_rt import Offset
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import erase_node
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/django_urls.py
+++ b/src/django_upgrade/fixers/django_urls.py
@@ -7,23 +7,26 @@ from __future__ import annotations
 import ast
 import re
 from functools import partial
-from typing import Iterable, MutableMapping
+from typing import Iterable
+from typing import MutableMapping
 from weakref import WeakKeyDictionary
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
 from django_upgrade.compat import str_removeprefix
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    STRING,
-    extract_indent,
-    find,
-    insert,
-    replace,
-    str_repr_matching,
-    update_import_names,
-)
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import extract_indent
+from django_upgrade.tokens import find
+from django_upgrade.tokens import insert
+from django_upgrade.tokens import replace
+from django_upgrade.tokens import str_repr_matching
+from django_upgrade.tokens import STRING
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/email_validator.py
+++ b/src/django_upgrade/fixers/email_validator.py
@@ -11,7 +11,9 @@ from typing import Iterable
 from tokenize_rt import Offset
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import replace_argument_names
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/forms_model_multiple_choice_field.py
+++ b/src/django_upgrade/fixers/forms_model_multiple_choice_field.py
@@ -11,7 +11,9 @@ from typing import Iterable
 from tokenize_rt import Offset
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import replace
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/jsonfield.py
+++ b/src/django_upgrade/fixers/jsonfield.py
@@ -10,8 +10,11 @@ from typing import Iterable
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import update_import_modules
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/management_commands.py
+++ b/src/django_upgrade/fixers/management_commands.py
@@ -11,7 +11,9 @@ from typing import Iterable
 from tokenize_rt import Offset
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import replace
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/null_boolean_field.py
+++ b/src/django_upgrade/fixers/null_boolean_field.py
@@ -8,18 +8,20 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    CODE,
-    OP,
-    find,
-    find_and_replace_name,
-    parse_call_args,
-    update_import_names,
-)
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import CODE
+from django_upgrade.tokens import find
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/on_delete.py
+++ b/src/django_upgrade/fixers/on_delete.py
@@ -6,14 +6,23 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import Iterable, MutableMapping
+from typing import Iterable
+from typing import MutableMapping
 from weakref import WeakKeyDictionary
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import OP, extract_indent, find, insert, parse_call_args
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import extract_indent
+from django_upgrade.tokens import find
+from django_upgrade.tokens import insert
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/password_reset_timeout_days.py
+++ b/src/django_upgrade/fixers/password_reset_timeout_days.py
@@ -8,11 +8,16 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import CODE, OP, find
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import CODE
+from django_upgrade.tokens import find
+from django_upgrade.tokens import OP
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/postgres_float_range_field.py
+++ b/src/django_upgrade/fixers/postgres_float_range_field.py
@@ -10,9 +10,13 @@ from typing import Iterable
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import find_and_replace_name, update_import_names
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/queryset_paginator.py
+++ b/src/django_upgrade/fixers/queryset_paginator.py
@@ -10,9 +10,13 @@ from typing import Iterable
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import find_and_replace_name, update_import_names
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -9,11 +9,18 @@ import sys
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import NAME, STRING, find, replace, str_repr_matching
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find
+from django_upgrade.tokens import NAME
+from django_upgrade.tokens import replace
+from django_upgrade.tokens import str_repr_matching
+from django_upgrade.tokens import STRING
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/settings_database_postgresql.py
+++ b/src/django_upgrade/fixers/settings_database_postgresql.py
@@ -8,11 +8,15 @@ from __future__ import annotations
 import ast
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import replace, str_repr_matching
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import replace
+from django_upgrade.tokens import str_repr_matching
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/signal_providing_args.py
+++ b/src/django_upgrade/fixers/signal_providing_args.py
@@ -8,20 +8,22 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import UNIMPORTANT_WS, Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
+from tokenize_rt import UNIMPORTANT_WS
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    CODE,
-    COMMENT,
-    INDENT,
-    OP,
-    consume,
-    find,
-    parse_call_args,
-    reverse_consume,
-)
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import CODE
+from django_upgrade.tokens import COMMENT
+from django_upgrade.tokens import consume
+from django_upgrade.tokens import find
+from django_upgrade.tokens import INDENT
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
+from django_upgrade.tokens import reverse_consume
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/testcase_databases.py
+++ b/src/django_upgrade/fixers/testcase_databases.py
@@ -8,11 +8,15 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import CODE, find_last_token
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import CODE
+from django_upgrade.tokens import find_last_token
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/timezone_fixedoffset.py
+++ b/src/django_upgrade/fixers/timezone_fixedoffset.py
@@ -8,19 +8,21 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    OP,
-    extract_indent,
-    find,
-    insert,
-    parse_call_args,
-    replace,
-    update_import_names,
-)
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import extract_indent
+from django_upgrade.tokens import find
+from django_upgrade.tokens import insert
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
+from django_upgrade.tokens import replace
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/use_l10n.py
+++ b/src/django_upgrade/fixers/use_l10n.py
@@ -11,7 +11,9 @@ from typing import Iterable
 from tokenize_rt import Offset
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import erase_node
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/utils_encoding.py
+++ b/src/django_upgrade/fixers/utils_encoding.py
@@ -10,9 +10,13 @@ from typing import Iterable
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import find_and_replace_name, update_import_names
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/utils_functional.py
+++ b/src/django_upgrade/fixers/utils_functional.py
@@ -10,8 +10,11 @@ from typing import Iterable
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import update_import_modules
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/utils_http.py
+++ b/src/django_upgrade/fixers/utils_http.py
@@ -8,16 +8,18 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    extract_indent,
-    find_and_replace_name,
-    insert,
-    update_import_names,
-)
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import extract_indent
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import insert
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/utils_text.py
+++ b/src/django_upgrade/fixers/utils_text.py
@@ -8,16 +8,17 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import (
-    extract_indent,
-    find_and_replace_name,
-    insert,
-    update_import_names,
-)
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import extract_indent
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import insert
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/utils_timezone.py
+++ b/src/django_upgrade/fixers/utils_timezone.py
@@ -6,14 +6,19 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import Iterable, MutableMapping
+from typing import Iterable
+from typing import MutableMapping
 from weakref import WeakKeyDictionary
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import replace, update_import_names
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import replace
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/utils_translation.py
+++ b/src/django_upgrade/fixers/utils_translation.py
@@ -10,9 +10,13 @@ from typing import Iterable
 
 from tokenize_rt import Offset
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
-from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import find_and_replace_name, update_import_names
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/versioned_branches.py
+++ b/src/django_upgrade/fixers/versioned_branches.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import Iterable, Literal, cast
+from typing import cast
+from typing import Iterable
+from typing import Literal
 
-from tokenize_rt import Offset, Token
+from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import Block
 
 fixer = Fixer(

--- a/src/django_upgrade/main.py
+++ b/src/django_upgrade/main.py
@@ -4,18 +4,19 @@ import argparse
 import sys
 import tokenize
 from importlib import metadata
-from typing import Sequence, Tuple, cast
+from typing import cast
+from typing import Sequence
+from typing import Tuple
 
-from tokenize_rt import (
-    UNIMPORTANT_WS,
-    Token,
-    reversed_enumerate,
-    src_to_tokens,
-    tokens_to_src,
-)
+from tokenize_rt import reversed_enumerate
+from tokenize_rt import src_to_tokens
+from tokenize_rt import Token
+from tokenize_rt import tokens_to_src
+from tokenize_rt import UNIMPORTANT_WS
 
 from django_upgrade.ast import ast_parse
-from django_upgrade.data import Settings, visit
+from django_upgrade.data import Settings
+from django_upgrade.data import visit
 from django_upgrade.tokens import DEDENT
 
 

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -4,7 +4,10 @@ import ast
 import re
 from collections import defaultdict
 
-from tokenize_rt import NON_CODING_TOKENS, UNIMPORTANT_WS, Token, tokens_to_src
+from tokenize_rt import NON_CODING_TOKENS
+from tokenize_rt import Token
+from tokenize_rt import tokens_to_src
+from tokenize_rt import UNIMPORTANT_WS
 
 # Token name aliases
 CODE = "CODE"  # Token name meaning 'replaced by us'

--- a/tests/fixers/test_admin_allow_tags.py
+++ b/tests/fixers/test_admin_allow_tags.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(2, 0))
 

--- a/tests/fixers/test_admin_decorators.py
+++ b/tests/fixers/test_admin_decorators.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 2))
 

--- a/tests/fixers/test_admin_register.py
+++ b/tests/fixers/test_admin_register.py
@@ -5,7 +5,8 @@ import sys
 import pytest
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(1, 7))
 

--- a/tests/fixers/test_assert_form_error.py
+++ b/tests/fixers/test_assert_form_error.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(4, 1))
 

--- a/tests/fixers/test_compatibility_imports_1_11.py
+++ b/tests/fixers/test_compatibility_imports_1_11.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(1, 11))
 

--- a/tests/fixers/test_compatibility_imports_1_9.py
+++ b/tests/fixers/test_compatibility_imports_1_9.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(1, 9))
 

--- a/tests/fixers/test_crypto_get_random_string.py
+++ b/tests/fixers/test_crypto_get_random_string.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 1))
 

--- a/tests/fixers/test_default_app_config.py
+++ b/tests/fixers/test_default_app_config.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 2))
 

--- a/tests/fixers/test_django_urls.py
+++ b/tests/fixers/test_django_urls.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(2, 2))
 

--- a/tests/fixers/test_email_validator.py
+++ b/tests/fixers/test_email_validator.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 2))
 

--- a/tests/fixers/test_forms_model_multiple_choice_field.py
+++ b/tests/fixers/test_forms_model_multiple_choice_field.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 1))
 

--- a/tests/fixers/test_jsonfield.py
+++ b/tests/fixers/test_jsonfield.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 1))
 

--- a/tests/fixers/test_management_commands.py
+++ b/tests/fixers/test_management_commands.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 2))
 

--- a/tests/fixers/test_null_boolean_field.py
+++ b/tests/fixers/test_null_boolean_field.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 1))
 

--- a/tests/fixers/test_on_delete.py
+++ b/tests/fixers/test_on_delete.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(1, 9))
 

--- a/tests/fixers/test_password_reset_timeout_days.py
+++ b/tests/fixers/test_password_reset_timeout_days.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 1))
 

--- a/tests/fixers/test_postgres_float_range_field.py
+++ b/tests/fixers/test_postgres_float_range_field.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(2, 2))
 

--- a/tests/fixers/test_queryset_paginator.py
+++ b/tests/fixers/test_queryset_paginator.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(2, 2))
 

--- a/tests/fixers/test_request_headers.py
+++ b/tests/fixers/test_request_headers.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(2, 2))
 

--- a/tests/fixers/test_settings_database_postgresql.py
+++ b/tests/fixers/test_settings_database_postgresql.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(1, 9))
 

--- a/tests/fixers/test_signal_providing_args.py
+++ b/tests/fixers/test_signal_providing_args.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 1))
 

--- a/tests/fixers/test_testcase_databases.py
+++ b/tests/fixers/test_testcase_databases.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(2, 2))
 

--- a/tests/fixers/test_timezone_fixedoffset.py
+++ b/tests/fixers/test_timezone_fixedoffset.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(2, 2))
 

--- a/tests/fixers/test_use_l10n.py
+++ b/tests/fixers/test_use_l10n.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(4, 0))
 

--- a/tests/fixers/test_utils_encoding.py
+++ b/tests/fixers/test_utils_encoding.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 0))
 

--- a/tests/fixers/test_utils_functional.py
+++ b/tests/fixers/test_utils_functional.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(2, 0))
 

--- a/tests/fixers/test_utils_http.py
+++ b/tests/fixers/test_utils_http.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 0))
 

--- a/tests/fixers/test_utils_text.py
+++ b/tests/fixers/test_utils_text.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 0))
 

--- a/tests/fixers/test_utils_timezone.py
+++ b/tests/fixers/test_utils_timezone.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(4, 1))
 

--- a/tests/fixers/test_utils_translation.py
+++ b/tests/fixers/test_utils_translation.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(3, 0))
 

--- a/tests/fixers/test_versioned_branches.py
+++ b/tests/fixers/test_versioned_branches.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop, check_transformed
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
 
 settings = Settings(target_version=(4, 0))
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 
 import pytest
 
-from django_upgrade.data import Settings, State
+from django_upgrade.data import Settings
+from django_upgrade.data import State
 
 settings = Settings(target_version=(4, 0))
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,10 +7,12 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
-from tokenize_rt import UNIMPORTANT_WS, src_to_tokens
+from tokenize_rt import src_to_tokens
+from tokenize_rt import UNIMPORTANT_WS
 
 from django_upgrade import __main__  # noqa: F401
-from django_upgrade.main import fixup_dedent_tokens, main
+from django_upgrade.main import fixup_dedent_tokens
+from django_upgrade.main import main
 from django_upgrade.tokens import DEDENT
 
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import ast
 
 import pytest
-from tokenize_rt import Token, src_to_tokens, tokens_to_src
+from tokenize_rt import src_to_tokens
+from tokenize_rt import Token
+from tokenize_rt import tokens_to_src
 
-from django_upgrade.tokens import str_repr_matching, update_import_names
+from django_upgrade.tokens import str_repr_matching
+from django_upgrade.tokens import update_import_names
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
