### PR TITLE
Make request.headers avoid rewriting `del` statements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+* Avoid rewriting ``request.META`` to ``request.headers`` in ``del`` statements.
+  This pattern works for ``request.META`` but not for ``request.headers`` which is an immutable Mapping.
+
+  Thanks to Thibaut Decombe in `PR #290 <https://github.com/adamchainz/django-upgrade/pull/290>`__.
 
 * Add Django 1.9+ fixer to rename the legacy engine name ``django.db.backends.postgresql_psycopg2`` in ``settings.DATABASES`` to ``django.db.backends.postgresql``.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,7 @@
 =======
 History
 =======
+
 * Avoid rewriting ``request.META`` to ``request.headers`` in ``del`` statements.
   This pattern works for ``request.META`` but not for ``request.headers`` which is an immutable Mapping.
 

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -35,7 +35,7 @@ def visit_Subscript(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        not isinstance(parents[-1], ast.Assign)
+        not isinstance(parents[-1], (ast.Assign, ast.Delete))
         and is_request_or_self_request_meta(node.value)
         and (meta_name := extract_constant(node.slice)) is not None
         and (header_name := get_header_name(meta_name)) is not None

--- a/tests/fixers/test_request_headers.py
+++ b/tests/fixers/test_request_headers.py
@@ -34,6 +34,15 @@ def test_assignment():
     )
 
 
+def test_delete():
+    check_noop(
+        """\
+        del request.META['HTTP_SERVER']
+        """,
+        settings,
+    )
+
+
 def test_in_not_header():
     check_noop(
         """\


### PR DESCRIPTION
Similar to what happened in #74, I ran into this issue:

```diff
-del request.META["HTTP_REFERER"]
+del request.headers["Referer"]
```

Which raises: `'HttpHeaders' object does not support item deletion`

I guess this is probably an odd pattern but we used it to add a temporary header in a middleware that we wanted to clean at the end. I added a small change to make sure we don't rewrite in that case.

Let me know if it feels right to you.
Cheers