### PR TITLE
Rename `lookup_needs_distinct` to `lookup_spawns_duplicates`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Add Django 4.0 fixer to rewrite ``django.contrib.admin.utils.lookup_needs_distinct`` -> ``lookup_spawns_duplicates``.
+
+  Thanks to Bruno Alla in `PR #313 <https://github.com/adamchainz/django-upgrade/pull/313>`__.
+
 * Group some compatibility import replacements into a single “fixer”, optimizing runtime by about 3%.
 
   Thanks to Thibaut Decombe in `PR #295 <https://github.com/adamchainz/django-upgrade/pull/295>`__.

--- a/README.rst
+++ b/README.rst
@@ -764,6 +764,19 @@ For example ``myproject/settings.py`` or ``myproject/settings/production.py``.
 
     -USE_L10N = True
 
+``lookup_needs_distinct``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Renames the undocumented ``django.contrib.admin.utils.lookup_needs_distinct`` to ``lookup_spawns_duplicates``:
+
+.. code-block:: diff
+    -from django.contrib.admin.utils import lookup_needs_distinct
+    +from django.contrib.admin.utils import lookup_spawns_duplicates
+
+    -if lookup_needs_distinct(self.opts, search_spec):
+    +if lookup_spawns_duplicates(self.opts, search_spec):
+        ...
+
 Django 4.1
 ----------
 

--- a/src/django_upgrade/fixers/admin_lookup_needs_distinct.py
+++ b/src/django_upgrade/fixers/admin_lookup_needs_distinct.py
@@ -55,14 +55,8 @@ def visit_Name(
     node: ast.Name,
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
-    if (name := node.id) in state.from_imports[MODULE]:
-        new_name: str | None
-        if name in RENAMES:
-            new_name = RENAMES[name]
-        else:
-            new_name = None
-
-        if new_name is not None:
-            yield ast_start_offset(node), partial(
-                find_and_replace_name, name=name, new=new_name
-            )
+    if (name := node.id) in RENAMES and name in state.from_imports[MODULE]:
+        new_name = RENAMES[name]
+        yield ast_start_offset(node), partial(
+            find_and_replace_name, name=name, new=new_name
+        )

--- a/src/django_upgrade/fixers/admin_lookup_needs_distinct.py
+++ b/src/django_upgrade/fixers/admin_lookup_needs_distinct.py
@@ -1,0 +1,68 @@
+"""
+Rename django.contrib.admin.utils.lookup_needs_distinct to lookup_spawns_duplicates:
+https://docs.djangoproject.com/en/4.0/releases/4.0/#miscellaneous
+"""
+from __future__ import annotations
+
+import ast
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import update_import_names
+
+fixer = Fixer(
+    __name__,
+    min_version=(4, 0),
+)
+
+MODULE = "django.contrib.admin.utils"
+RENAMES = {
+    "lookup_needs_distinct": "lookup_spawns_duplicates",
+}
+
+
+@fixer.register(ast.ImportFrom)
+def visit_ImportFrom(
+    state: State,
+    node: ast.ImportFrom,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if node.module == MODULE and is_rewritable_import_from(node):
+        name_map = {}
+        for alias in node.names:
+            if alias.name in RENAMES:
+                name_map[alias.name] = RENAMES[alias.name]
+
+        if name_map:
+            yield ast_start_offset(node), partial(
+                update_import_names,
+                node=node,
+                name_map=name_map,
+            )
+
+
+@fixer.register(ast.Name)
+def visit_Name(
+    state: State,
+    node: ast.Name,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (name := node.id) in state.from_imports[MODULE]:
+        new_name: str | None
+        if name in RENAMES:
+            new_name = RENAMES[name]
+        else:
+            new_name = None
+
+        if new_name is not None:
+            yield ast_start_offset(node), partial(
+                find_and_replace_name, name=name, new=new_name
+            )

--- a/tests/fixers/test_admin_lookup_needs_distinct.py
+++ b/tests/fixers/test_admin_lookup_needs_distinct.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(4, 0))
+
+
+def test_no_deprecated_alias():
+    check_noop(
+        """\
+        from django.contrib.admin.utils import something
+
+        something
+        """,
+        settings,
+    )
+
+
+def test_one_local_name():
+    check_transformed(
+        """\
+        from django.contrib.admin.utils import lookup_needs_distinct
+
+        x = lookup_needs_distinct(y)
+        """,
+        """\
+        from django.contrib.admin.utils import lookup_spawns_duplicates
+
+        x = lookup_spawns_duplicates(y)
+        """,
+        settings,
+    )
+
+
+def test_with_alias():
+    check_transformed(
+        """\
+        from django.contrib.admin.utils import lookup_needs_distinct as lnd
+
+        v = lnd("x")
+        """,
+        """\
+        from django.contrib.admin.utils import lookup_spawns_duplicates as lnd
+
+        v = lnd("x")
+        """,
+        settings,
+    )


### PR DESCRIPTION
Function is undocumented and was therefore renamed without deprecation in Django 4.0:

https://docs.djangoproject.com/en/4.0/releases/4.0/#miscellaneous

> The undocumented `django.contrib.admin.utils.lookup_needs_distinct()` function is renamed to `lookup_spawns_duplicates()`.