### PR TITLE
Add some compatibility imports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Changelog
 
   Thanks to Thibaut Decombe in `PR #369 <https://github.com/adamchainz/django-upgrade/pull/369>`__.
 
+* Add some compatibility import replacements for Django 4.0 and below.
+
+  Thanks to Thibaut Decombe in `PR #368 <https://github.com/adamchainz/django-upgrade/pull/368>`__.
+
 1.14.1 (2023-08-16)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -218,6 +218,22 @@ If a ``register()`` call is preceded by an ``unregister()`` call that includes t
     admin.site.unregister(MyModel1)
     admin.site.register(MyModel1, MyCustomAdmin)
 
+Compatibility imports
+~~~~~~~~~~~~~~~~~~~~~
+
+Rewrites some compatibility imports:
+
+* ``django.contrib.admin.helpers.ACTION_CHECKBOX_NAME`` in ``django.contrib.admin``
+* ``django.template.context.BaseContext``, ``django.template.context.Context``, ``django.template.context.ContextPopException`` and ``django.template.context.RequestContext`` in ``django.template.base``
+
+.. code-block:: diff
+
+    -from django.contrib.admin import ACTION_CHECKBOX_NAME
+    +from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
+
+    -from django.template.base import Context
+    +from django.template.context import Context
+
 Django 1.9
 -----------
 
@@ -277,6 +293,7 @@ Rewrites some compatibility imports:
 
 * ``django.forms.utils.pretty_name`` in ``django.forms.forms``
 * ``django.forms.boundfield.BoundField`` in ``django.forms.forms``
+* ``django.forms.widgets.SelectDateWidget`` in ``django.forms.extras``
 
 Whilst mentioned in the `Django 3.1 release notes <https://docs.djangoproject.com/en/3.1/releases/3.1/#id1>`_, these have been possible since Django 1.9.
 
@@ -284,6 +301,27 @@ Whilst mentioned in the `Django 3.1 release notes <https://docs.djangoproject.co
 
     -from django.forms.forms import pretty_name
     +from django.forms.utils import pretty_name
+
+Django 1.10
+-----------
+
+`Release Notes <https://docs.djangoproject.com/en/1.10/releases/1.10/>`__
+
+Compatibility imports
+~~~~~~~~~~~~~~~~~~~~~
+
+Rewrites some compatibility imports:
+
+* ``django.templatetags.static.static`` in ``django.contrib.staticfiles.templatetags.staticfiles``
+
+Whilst mentioned in the `Django 2.1 release notes <https://docs.djangoproject.com/en/2.1/releases/2.1/#features-deprecated-in-2-1>`_, these have been possible since Django 1.10.
+
+
+.. code-block:: diff
+
+    -from django.contrib.staticfiles.templatetags.staticfiles import static
+    +from django.templatetags.static import static
+
 
 Django 1.11
 -----------
@@ -378,6 +416,16 @@ Rewrites imports of ``lru_cache`` from ``django.utils.functional`` to use ``func
 
     -from django.utils.functional import lru_cache
     +from functools import lru_cache
+
+``ContextDecorator``
+~~~~~~~~~~~~~~~~~~~~
+
+Rewrites imports of ``ContextDecorator`` from ``django.utils.decorators`` to use ``contextlib``.
+
+.. code-block:: diff
+
+    -from django.utils.decorators import ContextDecorator
+    +from contextlib import ContextDecorator
 
 ``<func>.allow_tags = True``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -779,6 +827,18 @@ Renames the undocumented ``django.contrib.admin.utils.lookup_needs_distinct`` to
     -if lookup_needs_distinct(self.opts, search_spec):
     +if lookup_spawns_duplicates(self.opts, search_spec):
         ...
+
+Compatibility imports
+~~~~~~~~~~~~~~~~~~~~~
+
+Rewrites some compatibility imports:
+
+* ``django.utils.translation.template.TRANSLATOR_COMMENT_MARK`` in ``django.template.base``
+
+.. code-block:: diff
+
+    -from django.template.base import TRANSLATOR_COMMENT_MARK
+    +from django.utils.translation.template import TRANSLATOR_COMMENT_MARK
 
 Django 4.1
 ----------

--- a/src/django_upgrade/fixers/compatibility_imports.py
+++ b/src/django_upgrade/fixers/compatibility_imports.py
@@ -65,6 +65,11 @@ REPLACEMENTS_EXACT = {
             "JSONField": "django.forms",
         },
     },
+    (4, 0): {
+        "django.template.base": {
+            "TRANSLATOR_COMMENT_MARK": "django.utils.translation.template"
+        }
+    },
 }
 REPLACEMENTS_EXCEPT_MIGRATIONS = {
     (3, 1): {

--- a/src/django_upgrade/fixers/compatibility_imports.py
+++ b/src/django_upgrade/fixers/compatibility_imports.py
@@ -36,10 +36,27 @@ fixer = Fixer(
 )
 
 REPLACEMENTS_EXACT = {
+    (1, 7): {
+        "django.contrib.admin": {
+            "ACTION_CHECKBOX_NAME": "django.contrib.admin.helpers",
+        },
+        "django.template.base": {
+            "BaseContext": "django.template.context",
+            "Context": "django.template.context",
+            "ContextPopException": "django.template.context",
+            "RequestContext": "django.template.context",
+        },
+    },
     (1, 9): {
         "django.forms.forms": {
             "pretty_name": "django.forms.utils",
             "BoundField": "django.forms.boundfield",
+        },
+        "django.forms.extras": {"SelectDateWidget": "django.forms.widgets"},
+    },
+    (1, 10): {
+        "django.contrib.staticfiles.templatetags.staticfiles": {
+            "static": "django.templatetags.static",
         },
     },
     (1, 11): {
@@ -55,8 +72,12 @@ REPLACEMENTS_EXACT = {
         "django.db.models.sql.datastructures": {
             "EmptyResultSet": "django.core.exceptions",
         },
+        "django.test.runner": {"setup_databases": "django.test.utils"},
     },
-    (2, 0): {"django.utils.functional": {"lru_cache": "functools"}},
+    (2, 0): {
+        "django.utils.functional": {"lru_cache": "functools"},
+        "django.utils.decorators": {"ContextDecorator": "contextlib"},
+    },
     (3, 1): {
         "django.contrib.postgres.forms": {
             "JSONField": "django.forms",


### PR DESCRIPTION
Hi! 

I've added a compatibility import replacement for django 4.0 (`TRANSLATOR_COMMENT_MARK`, we were actually importing this in our code base at my work) and while at it, added some older one fitting existing target-version settings.

Fixes #293

I also noticed some compatibility imports were not mentioned in the readme so I've added the missing sections.

Cheers