### PR TITLE
Drop `.choices` from model field choices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* Support Django 5.0 as a target version. No fixers yet.
+* Support Django 5.0 as a target version.
 
 * Add Django 5.0+ fixer to drop ``.choices`` on model field ``choices`` parameters when using an enumeration type.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 
 * Support Django 5.0 as a target version. No fixers yet.
 
+* Add Django 5.0+ fixer to drop ``.choices`` on model field ``choices`` parameters when using an enumeration type.
+
+  Thanks to Thibaut Decombe in `PR #369 <https://github.com/adamchainz/django-upgrade/pull/369>`__.
+
 1.14.1 (2023-08-16)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -910,4 +910,13 @@ Django 5.0
 
 `Release Notes <https://docs.djangoproject.com/en/5.0/releases/5.0/>`__
 
-No fixers yet.
+``.choices``
+~~~~~~~~~~~~
+
+Drop ``.choices`` for model field ``choices`` parameters. This parameter now accept enumeration types directly.
+
+.. code-block:: diff
+
+     class Card(models.Model):
+    -    suit = models.IntegerField(choices=Suit.choices, default=Suit.DEFAULT)
+    +    suit = models.IntegerField(choices=Suit, default=Suit.DEFAULT)

--- a/README.rst
+++ b/README.rst
@@ -910,10 +910,11 @@ Django 5.0
 
 `Release Notes <https://docs.djangoproject.com/en/5.0/releases/5.0/>`__
 
-``.choices``
-~~~~~~~~~~~~
+Model field ``choices=<name>.choices``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Drop ``.choices`` for model field ``choices`` parameters. This parameter now accept enumeration types directly.
+Drop ``.choices`` for model field ``choices`` parameters.
+This parameter now accept enumeration types directly.
 
 .. code-block:: diff
 

--- a/README.rst
+++ b/README.rst
@@ -914,7 +914,7 @@ Model field ``choices=<name>.choices``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Drop ``.choices`` for model field ``choices`` parameters.
-This parameter now accept enumeration types directly.
+This parameter now accepts enumeration types directly.
 
 .. code-block:: diff
 

--- a/src/django_upgrade/fixers/model_field_choices.py
+++ b/src/django_upgrade/fixers/model_field_choices.py
@@ -16,6 +16,8 @@ from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import find_last_token
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import reverse_find
 
 fixer = Fixer(
     __name__,
@@ -51,4 +53,5 @@ def visit_Call(
 
 def remove_choices(tokens: list[Token], i: int, node: ast.Attribute) -> None:
     j = find_last_token(tokens, i, node=node)
-    del tokens[i + 1 : j + 1]
+    i = reverse_find(tokens, j, name=OP, src=".")
+    del tokens[i : j + 1]

--- a/src/django_upgrade/fixers/model_field_choices.py
+++ b/src/django_upgrade/fixers/model_field_choices.py
@@ -1,0 +1,58 @@
+"""
+Drop `.choices` for model field `choices` parameters:
+https://docs.djangoproject.com/en/5.0/releases/5.0/#forms
+"""
+from __future__ import annotations
+
+import ast
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find_last_token
+
+fixer = Fixer(
+    __name__,
+    min_version=(5, 0),
+)
+
+
+@fixer.register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        not state.looks_like_migrations_file
+        and (
+            (
+                isinstance(node.func, ast.Attribute)
+                and "models" in state.from_imports["django.db"]
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "models"
+            )
+            or (
+                isinstance(node.func, ast.Name)
+                and node.func.id in state.from_imports["django.db.models"]
+            )
+        )
+        and any(
+            kw.arg == "choices"
+            and isinstance(kw.value, ast.Attribute)
+            and (target_node := kw.value).attr == "choices"
+            for kw in node.keywords
+        )
+    ):
+        yield ast_start_offset(target_node), partial(remove_choices, node=target_node)
+
+
+def remove_choices(tokens: list[Token], i: int, node: ast.Attribute) -> None:
+    j = find_last_token(tokens, i, node=node)
+    del tokens[i + 1 : j + 1]

--- a/src/django_upgrade/fixers/model_field_choices.py
+++ b/src/django_upgrade/fixers/model_field_choices.py
@@ -30,7 +30,7 @@ def visit_Call(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        not state.looks_like_migrations_file
+        state.looks_like_models_file
         and (
             (
                 isinstance(node.func, ast.Attribute)

--- a/src/django_upgrade/fixers/model_field_choices.py
+++ b/src/django_upgrade/fixers/model_field_choices.py
@@ -34,14 +34,10 @@ def visit_Call(
         and (
             (
                 isinstance(node.func, ast.Attribute)
-                and "models" in state.from_imports["django.db"]
                 and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "models"
+                and node.func.attr.endswith("Field")
             )
-            or (
-                isinstance(node.func, ast.Name)
-                and node.func.id in state.from_imports["django.db.models"]
-            )
+            or (isinstance(node.func, ast.Name) and node.func.id.endswith("Field"))
         )
         and any(
             kw.arg == "choices"

--- a/tests/fixers/test_model_field_choices.py
+++ b/tests/fixers/test_model_field_choices.py
@@ -26,7 +26,7 @@ def test_untransformed_wrong_argument():
         CharField(default=Card.choices)
         """,
         settings,
-        filename="models/blog.py",
+        filename="models.py",
     )
 
 
@@ -41,7 +41,7 @@ def test_transform_full_import():
         CharField(choices=Card)
         """,
         settings,
-        filename="models/blog.py",
+        filename="models.py",
     )
 
 
@@ -56,7 +56,7 @@ def test_transform_module_import():
         field = models.BooleanField(choices=Card)
         """,
         settings,
-        filename="models/blog.py",
+        filename="models.py",
     )
 
 
@@ -71,7 +71,7 @@ def test_transform_with_kwarg_ending_comma():
         field = models.IntegerField(choices=Card,)
         """,
         settings,
-        filename="models/blog.py",
+        filename="models.py",
     )
 
 
@@ -90,7 +90,7 @@ def test_transform_with_kwargs_multiline():
         )
         """,
         settings,
-        filename="models/blog.py",
+        filename="models.py",
     )
 
 
@@ -116,7 +116,7 @@ def test_transform_with_weird_syntax():
         )
         """,
         settings,
-        filename="models/blog.py",
+        filename="models.py",
     )
 
 
@@ -131,7 +131,7 @@ def test_transform_external_package():
         field = MultiSelectField(choices=Card)
         """,
         settings,
-        filename="models/blog.py",
+        filename="models.py",
     )
 
 
@@ -150,5 +150,5 @@ def test_transform_other_app_package():
         field2 = CharField(choices=Card)
         """,
         settings,
-        filename="models/blog.py",
+        filename="models.py",
     )

--- a/tests/fixers/test_model_field_choices.py
+++ b/tests/fixers/test_model_field_choices.py
@@ -7,17 +7,6 @@ from tests.fixers.tools import check_transformed
 settings = Settings(target_version=(5, 0))
 
 
-def test_unmatched_import():
-    check_noop(
-        """\
-        from example import CharField
-        CharField(choices=Card.choices)
-        """,
-        settings,
-        filename="models/blog.py",
-    )
-
-
 def test_untransformed_in_migration_file():
     # No `.choices` in migrations anyway, every option are listed automatically.
     check_noop(
@@ -165,11 +154,15 @@ def test_transform_other_app_package():
     check_transformed(
         """\
         from my_app import custom_models
+        from example import CustomCharField
         field = custom_models.MyField(choices=Card.choices)
+        field2 = CharField(choices=Card.choices)
         """,
         """\
         from my_app import custom_models
+        from example import CustomCharField
         field = custom_models.MyField(choices=Card)
+        field2 = CharField(choices=Card)
         """,
         settings,
         filename="models/blog.py",

--- a/tests/fixers/test_model_field_choices.py
+++ b/tests/fixers/test_model_field_choices.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(5, 0))
+
+
+def test_unmatched_import():
+    check_noop(
+        """\
+        from example import CharField
+        CharField(choices=Card.choices)
+        """,
+        settings,
+    )
+
+
+def test_untransformed_in_migration_file():
+    check_noop(
+        """\
+        from django.db.models import CharField
+        CharField(choices=[(1, 2), (3, 4)]) # No .choices in migrations anyway
+        """,
+        settings,
+        filename="example/core/migrations/0001_initial.py",
+    )
+
+
+def test_untransformed_wrong_argument():
+    check_noop(
+        """\
+        from django.db.models import CharField
+        CharField(default=Card.choices)
+        """,
+        settings,
+    )
+
+
+def test_transform_full_import():
+    check_transformed(
+        """\
+        from django.db.models import CharField
+        CharField(choices=Card.choices)
+        """,
+        """\
+        from django.db.models import CharField
+        CharField(choices=Card)
+        """,
+        settings,
+    )
+
+
+def test_transform_module_import():
+    check_transformed(
+        """\
+        from django.db import models
+        field = models.BooleanField(choices=Card.choices)
+        """,
+        """\
+        from django.db import models
+        field = models.BooleanField(choices=Card)
+        """,
+        settings,
+    )
+
+
+def test_transform_with_kwarg_ending_comma():
+    check_transformed(
+        """\
+        from django.db import models
+        field = models.IntegerField(choices=Card.choices,)
+        """,
+        """\
+        from django.db import models
+        field = models.IntegerField(choices=Card,)
+        """,
+        settings,
+    )
+
+
+def test_transform_with_kwargs_multiline():
+    check_transformed(
+        """\
+        from django.db import models
+        field = models.IntegerField(
+            choices=Card.choices,
+        )
+        """,
+        """\
+        from django.db import models
+        field = models.IntegerField(
+            choices=Card,
+        )
+        """,
+        settings,
+    )
+
+
+def test_transform_with_weird_syntax():
+    check_transformed(
+        """\
+        from django.db import models
+        field = models.IntegerField(
+            choices=Card. choices,
+        )
+        field2 = models.IntegerField(
+            choices=Card.
+            choices,
+        )
+        """,
+        """\
+        from django.db import models
+        field = models.IntegerField(
+            choices=Card,
+        )
+        field2 = models.IntegerField(
+            choices=Card,
+        )
+        """,
+        settings,
+    )

--- a/tests/fixers/test_model_field_choices.py
+++ b/tests/fixers/test_model_field_choices.py
@@ -60,6 +60,21 @@ def test_transform_module_import():
     )
 
 
+def test_transform_choices_module_reference():
+    check_transformed(
+        """\
+        from django.db import models
+        field = models.IntegerField(choices=enums.Card.choices)
+        """,
+        """\
+        from django.db import models
+        field = models.IntegerField(choices=enums.Card)
+        """,
+        settings,
+        filename="models.py",
+    )
+
+
 def test_transform_with_kwarg_ending_comma():
     check_transformed(
         """\

--- a/tests/fixers/test_model_field_choices.py
+++ b/tests/fixers/test_model_field_choices.py
@@ -60,21 +60,6 @@ def test_transform_module_import():
     )
 
 
-def test_transform_gis_models_import():
-    check_transformed(
-        """\
-        from django.contrib.postgres.fields import ArrayField
-        field = ArrayField(choices=Card.choices)
-        """,
-        """\
-        from django.contrib.postgres.fields import ArrayField
-        field = ArrayField(choices=Card)
-        """,
-        settings,
-        filename="models/blog.py",
-    )
-
-
 def test_transform_with_kwarg_ending_comma():
     check_transformed(
         """\

--- a/tests/fixers/test_model_field_choices.py
+++ b/tests/fixers/test_model_field_choices.py
@@ -14,6 +14,7 @@ def test_unmatched_import():
         CharField(choices=Card.choices)
         """,
         settings,
+        filename="models/blog.py",
     )
 
 
@@ -36,6 +37,7 @@ def test_untransformed_wrong_argument():
         CharField(default=Card.choices)
         """,
         settings,
+        filename="models/blog.py",
     )
 
 
@@ -50,6 +52,7 @@ def test_transform_full_import():
         CharField(choices=Card)
         """,
         settings,
+        filename="models/blog.py",
     )
 
 
@@ -64,6 +67,22 @@ def test_transform_module_import():
         field = models.BooleanField(choices=Card)
         """,
         settings,
+        filename="models/blog.py",
+    )
+
+
+def test_transform_gis_models_import():
+    check_transformed(
+        """\
+        from django.contrib.postgres.fields import ArrayField
+        field = ArrayField(choices=Card.choices)
+        """,
+        """\
+        from django.contrib.postgres.fields import ArrayField
+        field = ArrayField(choices=Card)
+        """,
+        settings,
+        filename="models/blog.py",
     )
 
 
@@ -78,6 +97,7 @@ def test_transform_with_kwarg_ending_comma():
         field = models.IntegerField(choices=Card,)
         """,
         settings,
+        filename="models/blog.py",
     )
 
 
@@ -96,6 +116,7 @@ def test_transform_with_kwargs_multiline():
         )
         """,
         settings,
+        filename="models/blog.py",
     )
 
 
@@ -121,4 +142,35 @@ def test_transform_with_weird_syntax():
         )
         """,
         settings,
+        filename="models/blog.py",
+    )
+
+
+def test_transform_external_package():
+    check_transformed(
+        """\
+        from multiselectfield import MultiSelectField
+        field = MultiSelectField(choices=Card.choices)
+        """,
+        """\
+        from multiselectfield import MultiSelectField
+        field = MultiSelectField(choices=Card)
+        """,
+        settings,
+        filename="models/blog.py",
+    )
+
+
+def test_transform_other_app_package():
+    check_transformed(
+        """\
+        from my_app import custom_models
+        field = custom_models.MyField(choices=Card.choices)
+        """,
+        """\
+        from my_app import custom_models
+        field = custom_models.MyField(choices=Card)
+        """,
+        settings,
+        filename="models/blog.py",
     )

--- a/tests/fixers/test_model_field_choices.py
+++ b/tests/fixers/test_model_field_choices.py
@@ -18,10 +18,11 @@ def test_unmatched_import():
 
 
 def test_untransformed_in_migration_file():
+    # No `.choices` in migrations anyway, every option are listed automatically.
     check_noop(
         """\
         from django.db.models import CharField
-        CharField(choices=[(1, 2), (3, 4)]) # No .choices in migrations anyway
+        CharField(choices=[(1, 2), (3, 4)])
         """,
         settings,
         filename="example/core/migrations/0001_initial.py",


### PR DESCRIPTION
Fixes #336 

This might break if someone designed a custom class with a `choices` property which is not a django enumeration class but I don't think this is really a use case ?
The documentation links are not yet valid, I think we have to play the waiting game when this MR seems ready for you.

Cheers