### PR TITLE
`redirect(reverse(...))`  -> `redirect(...)` fixer

### DIFF
--- a/src/django_upgrade/fixers/redirect_reverse.py
+++ b/src/django_upgrade/fixers/redirect_reverse.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import ast
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
+
+fixer = Fixer(
+    __name__,
+    min_version=(0, 0),
+)
+
+
+@fixer.register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        isinstance(node.func, ast.Name)
+        and node.func.id == "redirect"
+        and len(node.args) == 1
+        and (
+            len(node.keywords) == 0
+            or len(node.keywords) == 1
+            and node.keywords[0].arg == "permanent"
+        )
+        and isinstance(node.args[0], ast.Call)
+        and isinstance(node.args[0].func, ast.Name)
+        and node.args[0].func.id == "reverse"
+        and len(node.args[0].args) == 1
+        and len(node.args[0].keywords) == 0
+    ):
+        yield ast_start_offset(node), remove_nested_reverse
+
+
+def remove_nested_reverse(tokens: list[Token], i: int) -> None:
+    redirect_open_idx = find(tokens, i, name=OP, src="(")
+    func_args, _ = parse_call_args(tokens, redirect_open_idx)
+
+    reverse_open_idx = find(tokens, func_args[0][0], name=OP, src="(")
+    reverse_args, reverse_close_idx = parse_call_args(tokens, reverse_open_idx)
+
+    del tokens[reverse_args[-1][1] : reverse_close_idx]
+    del tokens[redirect_open_idx:reverse_open_idx]

--- a/tests/fixers/test_redirect_reverse.py
+++ b/tests/fixers/test_redirect_reverse.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(5, 0))
+
+
+def test_noop_reverse_with_urlconf():
+    check_noop(
+        """\
+        redirect(reverse("my_app:my_view", urlconf="bbb"))
+        """,
+        settings,
+    )
+
+
+def test_noop_reverse_with_current_app():
+    check_noop(
+        """\
+        redirect(reverse("my_app:my_view", current_app="myapp"))
+        """,
+        settings,
+    )
+
+
+def test_noop_reverse_with_kwargs():
+    # We would have to splat kwargs in redirect which makes the function
+    # call hard to understand and is not safe if one the kwargs happens
+    # to be named `permanent` (which is one of `redirect` kwargs)
+    check_noop(
+        """\
+        redirect(reverse("my_app:my_view", kwargs={"tag": "youou"}))
+        """,
+        settings,
+    )
+
+
+def test_noop_reverse_with_args():
+    check_noop(
+        """\
+        redirect(reverse("arch-summary", args=[1945]))
+        """,
+        settings,
+    )
+
+
+def test_transform():
+    check_transformed(
+        """\
+        redirect(reverse("my_app:my_view"))
+        """,
+        """\
+        redirect("my_app:my_view")
+        """,
+        settings,
+    )
+
+
+def test_transform_multiline():
+    check_transformed(
+        """\
+        redirect(
+            reverse(
+                "my_app:my_view",
+            )
+        )
+        """,
+        """\
+        redirect(
+                "my_app:my_view"
+        )
+        """,
+        settings,
+    )
+
+
+def test_transform_redirect_permanent():
+    check_transformed(
+        """\
+        redirect(reverse("my_app:my_view"), permanent=True)
+        """,
+        """\
+        redirect("my_app:my_view", permanent=True)
+        """,
+        settings,
+    )
+
+
+def test_transform_redirect_permanent_multiline():
+    check_transformed(
+        """\
+        redirect(
+            reverse(
+                "my_app:my_view",
+            ),
+            permanent=True,
+        )
+        """,
+        """\
+        redirect(
+                "my_app:my_view",
+            permanent=True,
+        )
+        """,
+        settings,
+    )


### PR DESCRIPTION
Remove redundant call to reverse in redirect

```diff
-redirect(reverse("my_app:my_view"))
+redirect("my_app:my_view")
```

Other possible rewrites are skipped because they are actually less readable:
<details><summary>
</summary>

</details>

