### PR TITLE
Use isort to sort imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,16 +42,11 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==23.1.0
-- repo: https://github.com/asottile/reorder-python-imports
-  rev: v3.12.0
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
   hooks:
-  - id: reorder-python-imports
-    args:
-    - --py38-plus
-    - --application-directories
-    - .:example:src
-    - --add-import
-    - 'from __future__ import annotations'
+    - id: isort
+      name: isort (python)
 - repo: https://github.com/PyCQA/flake8
   rev: 7.0.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,13 @@ django-upgrade = "django_upgrade.main:main"
 [tool.black]
 target-version = ['py38']
 
+[tool.isort]
+add_imports = [
+    "from __future__ import annotations"
+]
+force_single_line = true
+profile = "black"
+
 [tool.pytest.ini_options]
 addopts = """\
     --strict-config

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -5,13 +5,13 @@ import pkgutil
 import re
 from collections import defaultdict
 from functools import cached_property
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import DefaultDict
 from typing import Iterable
 from typing import List
 from typing import Tuple
-from typing import TYPE_CHECKING
 from typing import TypeVar
 
 from tokenize_rt import Offset

--- a/src/django_upgrade/fixers/admin_decorators.py
+++ b/src/django_upgrade/fixers/admin_decorators.py
@@ -19,11 +19,11 @@ from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import erase_node
 from django_upgrade.tokens import extract_indent
 from django_upgrade.tokens import find_last_token
 from django_upgrade.tokens import insert
-from django_upgrade.tokens import OP
 from django_upgrade.tokens import reverse_find
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/admin_register.py
+++ b/src/django_upgrade/fixers/admin_register.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import cast
 from typing import Iterable
 from typing import Literal
 from typing import MutableMapping
+from typing import cast
 from weakref import WeakKeyDictionary
 
 from tokenize_rt import Offset
@@ -19,10 +19,10 @@ from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import erase_node
 from django_upgrade.tokens import extract_indent
 from django_upgrade.tokens import insert
-from django_upgrade.tokens import OP
 from django_upgrade.tokens import reverse_find
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/assert_form_error.py
+++ b/src/django_upgrade/fixers/assert_form_error.py
@@ -11,21 +11,21 @@ from functools import partial
 from typing import Any
 from typing import Iterable
 
+from tokenize_rt import UNIMPORTANT_WS
 from tokenize_rt import Offset
 from tokenize_rt import Token
 from tokenize_rt import tokens_to_src
-from tokenize_rt import UNIMPORTANT_WS
 
 from django_upgrade.ast import ast_start_offset
 from django_upgrade.ast import looks_like_test_client_call
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import PHYSICAL_NEWLINE
 from django_upgrade.tokens import consume
 from django_upgrade.tokens import find_first_token
 from django_upgrade.tokens import find_last_token
-from django_upgrade.tokens import OP
-from django_upgrade.tokens import PHYSICAL_NEWLINE
 from django_upgrade.tokens import replace
 from django_upgrade.tokens import reverse_consume
 

--- a/src/django_upgrade/fixers/crypto_get_random_string.py
+++ b/src/django_upgrade/fixers/crypto_get_random_string.py
@@ -16,8 +16,8 @@ from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import CODE
-from django_upgrade.tokens import find
 from django_upgrade.tokens import OP
+from django_upgrade.tokens import find
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/django_urls.py
+++ b/src/django_upgrade/fixers/django_urls.py
@@ -21,12 +21,12 @@ from django_upgrade.compat import str_removesuffix
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import STRING
 from django_upgrade.tokens import extract_indent
 from django_upgrade.tokens import find
 from django_upgrade.tokens import insert
 from django_upgrade.tokens import replace
 from django_upgrade.tokens import str_repr_matching
-from django_upgrade.tokens import STRING
 from django_upgrade.tokens import update_import_names
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/model_field_choices.py
+++ b/src/django_upgrade/fixers/model_field_choices.py
@@ -15,8 +15,8 @@ from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
-from django_upgrade.tokens import find_last_token
 from django_upgrade.tokens import OP
+from django_upgrade.tokens import find_last_token
 from django_upgrade.tokens import reverse_find
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/null_boolean_field.py
+++ b/src/django_upgrade/fixers/null_boolean_field.py
@@ -17,9 +17,9 @@ from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import CODE
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import find
 from django_upgrade.tokens import find_and_replace_name
-from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import update_import_names
 

--- a/src/django_upgrade/fixers/on_delete.py
+++ b/src/django_upgrade/fixers/on_delete.py
@@ -18,10 +18,10 @@ from django_upgrade.ast import is_rewritable_import_from
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import extract_indent
 from django_upgrade.tokens import find
 from django_upgrade.tokens import insert
-from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
 
 fixer = Fixer(

--- a/src/django_upgrade/fixers/password_reset_timeout_days.py
+++ b/src/django_upgrade/fixers/password_reset_timeout_days.py
@@ -16,8 +16,8 @@ from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import CODE
-from django_upgrade.tokens import find
 from django_upgrade.tokens import OP
+from django_upgrade.tokens import find
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/request_headers.py
+++ b/src/django_upgrade/fixers/request_headers.py
@@ -16,11 +16,11 @@ from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
-from django_upgrade.tokens import find
 from django_upgrade.tokens import NAME
+from django_upgrade.tokens import STRING
+from django_upgrade.tokens import find
 from django_upgrade.tokens import replace
 from django_upgrade.tokens import str_repr_matching
-from django_upgrade.tokens import STRING
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/settings_storages.py
+++ b/src/django_upgrade/fixers/settings_storages.py
@@ -17,10 +17,10 @@ from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import STRING
 from django_upgrade.tokens import erase_node
 from django_upgrade.tokens import find
 from django_upgrade.tokens import insert
-from django_upgrade.tokens import STRING
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/signal_providing_args.py
+++ b/src/django_upgrade/fixers/signal_providing_args.py
@@ -8,9 +8,9 @@ import ast
 from functools import partial
 from typing import Iterable
 
+from tokenize_rt import UNIMPORTANT_WS
 from tokenize_rt import Offset
 from tokenize_rt import Token
-from tokenize_rt import UNIMPORTANT_WS
 
 from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer
@@ -18,10 +18,10 @@ from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import CODE
 from django_upgrade.tokens import COMMENT
-from django_upgrade.tokens import consume
-from django_upgrade.tokens import find
 from django_upgrade.tokens import INDENT
 from django_upgrade.tokens import OP
+from django_upgrade.tokens import consume
+from django_upgrade.tokens import find
 from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import reverse_consume
 

--- a/src/django_upgrade/fixers/test_http_headers.py
+++ b/src/django_upgrade/fixers/test_http_headers.py
@@ -9,12 +9,12 @@ import ast
 import sys
 from bisect import bisect
 from functools import partial
-from typing import cast
 from typing import Iterable
+from typing import cast
 
+from tokenize_rt import UNIMPORTANT_WS
 from tokenize_rt import Offset
 from tokenize_rt import Token
-from tokenize_rt import UNIMPORTANT_WS
 
 from django_upgrade.ast import ast_start_offset
 from django_upgrade.ast import looks_like_test_client_call
@@ -23,13 +23,13 @@ from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import COMMENT
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import PHYSICAL_NEWLINE
 from django_upgrade.tokens import consume
 from django_upgrade.tokens import find
 from django_upgrade.tokens import find_first_token
 from django_upgrade.tokens import find_last_token
 from django_upgrade.tokens import insert
-from django_upgrade.tokens import OP
-from django_upgrade.tokens import PHYSICAL_NEWLINE
 
 fixer = Fixer(
     __name__,

--- a/src/django_upgrade/fixers/timezone_fixedoffset.py
+++ b/src/django_upgrade/fixers/timezone_fixedoffset.py
@@ -16,10 +16,10 @@ from django_upgrade.ast import is_rewritable_import_from
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import extract_indent
 from django_upgrade.tokens import find
 from django_upgrade.tokens import insert
-from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import replace
 from django_upgrade.tokens import update_import_names

--- a/src/django_upgrade/fixers/versioned_branches.py
+++ b/src/django_upgrade/fixers/versioned_branches.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import cast
 from typing import Iterable
 from typing import Literal
+from typing import cast
 
 from tokenize_rt import Offset
 from tokenize_rt import Token

--- a/src/django_upgrade/main.py
+++ b/src/django_upgrade/main.py
@@ -4,15 +4,15 @@ import argparse
 import sys
 import tokenize
 from importlib import metadata
-from typing import cast
 from typing import Sequence
 from typing import Tuple
+from typing import cast
 
+from tokenize_rt import UNIMPORTANT_WS
+from tokenize_rt import Token
 from tokenize_rt import reversed_enumerate
 from tokenize_rt import src_to_tokens
-from tokenize_rt import Token
 from tokenize_rt import tokens_to_src
-from tokenize_rt import UNIMPORTANT_WS
 
 from django_upgrade.ast import ast_parse
 from django_upgrade.data import Settings

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -5,9 +5,9 @@ import re
 from collections import defaultdict
 
 from tokenize_rt import NON_CODING_TOKENS
+from tokenize_rt import UNIMPORTANT_WS
 from tokenize_rt import Token
 from tokenize_rt import tokens_to_src
-from tokenize_rt import UNIMPORTANT_WS
 
 # Token name aliases
 CODE = "CODE"  # Token name meaning 'replaced by us'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,8 +7,8 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
-from tokenize_rt import src_to_tokens
 from tokenize_rt import UNIMPORTANT_WS
+from tokenize_rt import src_to_tokens
 
 from django_upgrade import __main__  # noqa: F401
 from django_upgrade.main import fixup_dedent_tokens

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import ast
 
 import pytest
-from tokenize_rt import src_to_tokens
 from tokenize_rt import Token
+from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src
 
 from django_upgrade.tokens import str_repr_matching


### PR DESCRIPTION
Switching because reorder-python-imports is incompatible with Black 24: https://github.com/asottile/reorder-python-imports/issues/366  / https://github.com/psf/black/issues/4175 .
