### PR TITLE
Update Django version references to 5.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` f
         rev: ""  # replace with latest tag on GitHub
         hooks:
         -   id: django-upgrade
-            args: [--target-version, "4.1"]   # Replace with Django version
+            args: [--target-version, "4.2"]   # Replace with Django version
 
 Then, upgrade your entire project:
 
@@ -78,7 +78,7 @@ For example:
 
 .. code-block:: sh
 
-    django-upgrade --target-version 4.1 example/core/models.py example/settings.py
+    django-upgrade --target-version 4.2 example/core/models.py example/settings.py
 
 The ``--target-version`` flag defaults to 2.2, the oldest supported version when this project was created.
 For more on usage run ``django-upgrade --help``.
@@ -96,7 +96,7 @@ For example, |with git ls-files pipe xargs|_:
 
 .. code-block:: sh
 
-    git ls-files -z -- '*.py' | xargs -0 django-upgrade --target-version 4.1
+    git ls-files -z -- '*.py' | xargs -0 django-upgrade --target-version 4.2
 
 …or PowerShell’s |ForEach-Object|__:
 
@@ -105,7 +105,7 @@ __ https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core
 
 .. code-block:: powershell
 
-    git ls-files -- '*.py' | %{django-upgrade --target-version 4.1 $_}
+    git ls-files -- '*.py' | %{django-upgrade --target-version 4.2 $_}
 
 The full list of fixers is documented below.
 

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Add the following to the ``repos`` section of your ``.pre-commit-config.yaml`` f
         rev: ""  # replace with latest tag on GitHub
         hooks:
         -   id: django-upgrade
-            args: [--target-version, "4.2"]   # Replace with Django version
+            args: [--target-version, "5.0"]   # Replace with Django version
 
 Then, upgrade your entire project:
 
@@ -78,7 +78,7 @@ For example:
 
 .. code-block:: sh
 
-    django-upgrade --target-version 4.2 example/core/models.py example/settings.py
+    django-upgrade --target-version 5.0 example/core/models.py example/settings.py
 
 The ``--target-version`` flag defaults to 2.2, the oldest supported version when this project was created.
 For more on usage run ``django-upgrade --help``.
@@ -96,7 +96,7 @@ For example, |with git ls-files pipe xargs|_:
 
 .. code-block:: sh
 
-    git ls-files -z -- '*.py' | xargs -0 django-upgrade --target-version 4.2
+    git ls-files -z -- '*.py' | xargs -0 django-upgrade --target-version 5.0
 
 …or PowerShell’s |ForEach-Object|__:
 
@@ -105,7 +105,7 @@ __ https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core
 
 .. code-block:: powershell
 
-    git ls-files -- '*.py' | %{django-upgrade --target-version 4.2 $_}
+    git ls-files -- '*.py' | %{django-upgrade --target-version 5.0 $_}
 
 The full list of fixers is documented below.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Framework :: Django :: 3.2",
   "Framework :: Django :: 4.0",
   "Framework :: Django :: 4.1",
+  "Framework :: Django :: 4.2",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Framework :: Django :: 4.0",
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",


### PR DESCRIPTION
I was checking the repository and realized Django 4.1 and 5.0 is not in the classifiers list. I added 4.2 with this PR, and updated its mentions from README.md . I believe that not having an EOL - insecure version in the docs is a small but important fix.