### PR TITLE
Run per-file conditions once

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Run per-file conditions once, yielding a performance improvement of ~2% measured on a real-world project.
+
 1.16.0 (2024-02-11)
 -------------------
 

--- a/src/django_upgrade/fixers/assert_form_error.py
+++ b/src/django_upgrade/fixers/assert_form_error.py
@@ -33,6 +33,7 @@ from django_upgrade.tokens import reverse_consume
 fixer = Fixer(
     __name__,
     min_version=(4, 1),
+    condition=lambda state: state.looks_like_test_file,
 )
 
 
@@ -43,8 +44,7 @@ def visit_Call(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_test_file
-        and isinstance(node.func, ast.Attribute)
+        isinstance(node.func, ast.Attribute)
         and (func_name := node.func.attr) in ("assertFormError", "assertFormsetError")
         and isinstance(node.func.value, ast.Name)
         and node.func.value.id == "self"

--- a/src/django_upgrade/fixers/assert_set_methods.py
+++ b/src/django_upgrade/fixers/assert_set_methods.py
@@ -21,6 +21,7 @@ from django_upgrade.tokens import find_and_replace_name
 fixer = Fixer(
     __name__,
     min_version=(4, 2),
+    condition=lambda state: state.looks_like_test_file,
 )
 
 MODULE = "django.test.testcase"
@@ -37,8 +38,7 @@ def visit_Call(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_test_file
-        and isinstance(func := node.func, ast.Attribute)
+        isinstance(func := node.func, ast.Attribute)
         and (name := func.attr) in NAMES
         and isinstance(func.value, ast.Name)
         and func.value.id == "self"

--- a/src/django_upgrade/fixers/default_app_config.py
+++ b/src/django_upgrade/fixers/default_app_config.py
@@ -20,6 +20,7 @@ from django_upgrade.tokens import erase_node
 fixer = Fixer(
     __name__,
     min_version=(3, 2),
+    condition=lambda state: state.looks_like_dunder_init_file,
 )
 
 
@@ -30,8 +31,7 @@ def visit_Assign(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_dunder_init_file
-        and isinstance(parents[-1], ast.Module)
+        isinstance(parents[-1], ast.Module)
         and len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
         and node.targets[0].id == "default_app_config"

--- a/src/django_upgrade/fixers/management_commands.py
+++ b/src/django_upgrade/fixers/management_commands.py
@@ -20,6 +20,7 @@ from django_upgrade.tokens import replace
 fixer = Fixer(
     __name__,
     min_version=(3, 2),
+    condition=lambda state: state.looks_like_command_file,
 )
 
 
@@ -30,8 +31,7 @@ def visit_Assign(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_command_file
-        and isinstance(parents[-1], ast.ClassDef)
+        isinstance(parents[-1], ast.ClassDef)
         and len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
         and node.targets[0].id == "requires_system_checks"

--- a/src/django_upgrade/fixers/password_reset_timeout_days.py
+++ b/src/django_upgrade/fixers/password_reset_timeout_days.py
@@ -23,6 +23,7 @@ from django_upgrade.tokens import find
 fixer = Fixer(
     __name__,
     min_version=(3, 1),
+    condition=lambda state: state.looks_like_settings_file,
 )
 
 OLD_NAME = "PASSWORD_RESET_TIMEOUT_DAYS"
@@ -36,8 +37,7 @@ def visit_Assign(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_settings_file
-        and len(node.targets) == 1
+        len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
         and node.targets[0].id == OLD_NAME
     ):

--- a/src/django_upgrade/fixers/settings_database_postgresql.py
+++ b/src/django_upgrade/fixers/settings_database_postgresql.py
@@ -22,6 +22,7 @@ from django_upgrade.tokens import str_repr_matching
 fixer = Fixer(
     __name__,
     min_version=(1, 9),
+    condition=lambda state: state.looks_like_settings_file,
 )
 
 
@@ -32,8 +33,7 @@ def visit_Dict(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_settings_file
-        and len(parents) >= 2
+        len(parents) >= 2
         and isinstance(parents[-1], ast.Dict)
         and isinstance((db_setting := parents[-2]), ast.Assign)
         and len(db_setting.targets) == 1

--- a/src/django_upgrade/fixers/settings_storages.py
+++ b/src/django_upgrade/fixers/settings_storages.py
@@ -26,6 +26,7 @@ from django_upgrade.tokens import insert
 fixer = Fixer(
     __name__,
     min_version=(4, 2),
+    condition=lambda state: state.looks_like_settings_file,
 )
 
 # Keep track of seen assignments
@@ -85,8 +86,7 @@ def visit_Assign(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_settings_file
-        and len(node.targets) == 1
+        len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
         and (
             (name := node.targets[0].id)

--- a/src/django_upgrade/fixers/test_http_headers.py
+++ b/src/django_upgrade/fixers/test_http_headers.py
@@ -35,6 +35,7 @@ from django_upgrade.tokens import insert
 fixer = Fixer(
     __name__,
     min_version=(4, 2),
+    condition=lambda state: state.looks_like_test_file,
 )
 
 HEADERS_KWARG = "headers"
@@ -49,14 +50,11 @@ if sys.version_info >= (3, 9):
         node: ast.Call,
         parents: list[ast.AST],
     ) -> Iterable[tuple[Offset, TokenFunc]]:
-        if state.looks_like_test_file and (
-            (
-                isinstance(node.func, ast.Name)
-                and node.func.id in ("Client", "RequestFactory")
-                and node.func.id in state.from_imports["django.test"]
-            )
-            or looks_like_test_client_call(node, "client")
-        ):
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in ("Client", "RequestFactory")
+            and node.func.id in state.from_imports["django.test"]
+        ) or looks_like_test_client_call(node, "client"):
             has_http_kwarg = False
             headers_keyword = None
             for keyword in node.keywords:

--- a/src/django_upgrade/fixers/testcase_databases.py
+++ b/src/django_upgrade/fixers/testcase_databases.py
@@ -22,6 +22,7 @@ from django_upgrade.tokens import find_last_token
 fixer = Fixer(
     __name__,
     min_version=(2, 2),
+    condition=lambda state: state.looks_like_test_file,
 )
 
 
@@ -32,8 +33,7 @@ def visit_Assign(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_test_file
-        and isinstance(parents[-1], ast.ClassDef)
+        isinstance(parents[-1], ast.ClassDef)
         and len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
         and node.targets[0].id in ("allow_database_queries", "multi_db")

--- a/src/django_upgrade/fixers/use_l10n.py
+++ b/src/django_upgrade/fixers/use_l10n.py
@@ -20,6 +20,7 @@ from django_upgrade.tokens import erase_node
 fixer = Fixer(
     __name__,
     min_version=(4, 0),
+    condition=lambda state: state.looks_like_settings_file,
 )
 
 
@@ -30,8 +31,7 @@ def visit_Assign(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        state.looks_like_settings_file
-        and len(node.targets) == 1
+        len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
         and node.targets[0].id == "USE_L10N"
         and isinstance(node.value, ast.Constant)

--- a/tests/fixers/test_settings_storages.py
+++ b/tests/fixers/test_settings_storages.py
@@ -24,6 +24,7 @@ def test_not_within_module():
         if PRODUCTION:
             DEFAULT_FILE_STORAGE = "example.backend"
         """,
+        filename="settings.py",
     )
 
 

--- a/tests/fixers/test_settings_storages.py
+++ b/tests/fixers/test_settings_storages.py
@@ -18,11 +18,20 @@ def test_not_settings_file():
     )
 
 
-def test_not_within_module():
+def test_not_module_level():
     check_noop(
         """\
         if PRODUCTION:
             DEFAULT_FILE_STORAGE = "example.backend"
+        """,
+        filename="settings.py",
+    )
+
+
+def test_not_expected_name():
+    check_noop(
+        """\
+        CUSTOM_FILE_STORAGE = "example.backend"
         """,
         filename="settings.py",
     )


### PR DESCRIPTION
Pushing the per-file conditions from fixer functions up to a per-file pre-pass stage can save many function calls and repeat checks. This yields a small but notable performance improvement.

Benchmarked in two ways.

**First,** using [pytest-profiling](https://pypi.org/project/pytest-profiling/) to measure the test suite:

**Before:** 1574686 function calls (1538837 primitive calls) in 1.308 seconds
**After:** 1569930 function calls (1534037 primitive calls) in 1.297 seconds

A removal of 4756 function calls, which is pretty impressive given the test snippets are small. I don’t read much into the performance improvement here.

**Second,** running on a client project of 50,475 lines of code across 268 files. Each condition was run 10 times with hyperfine.

**Before:** 557.4 ms ± 5.9 ms

**After:** 546.2 ms ± 3.9 ms

About 2% faster.