### PR TITLE
Add fixer selection options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 
 * Run per-file conditions once, yielding a performance improvement of ~2% measured on a real-world project.
 
+* Add ability to run specific fixers with ``--only <fixer_name>``
+
+* Add ability to skip specific fixers with ``--skip <fixer_name>``
+
+* Add ability to list all possible fixers with ``--list-fixers``
+
+  Thanks to Gav O'Connor in `PR #443 <https://github.com/adamchainz/django-upgrade/pull/443>`__.
+
+  Thanks to David Szotten in `PR #333 <https://github.com/adamchainz/django-upgrade/pull/333>`__.
+
 1.16.0 (2024-02-11)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,17 +2,11 @@
 Changelog
 =========
 
+* Add fixer selection options: ``--only <name>``, ``--skip <name>``, and ``--list-fixers``.
+
+  Thanks to Gav O'Connor and David Szotten in `PR #443 <https://github.com/adamchainz/django-upgrade/pull/443>`__.
+
 * Run per-file conditions once, yielding a performance improvement of ~2% measured on a real-world project.
-
-* Add ability to run specific fixers with ``--only <fixer_name>``
-
-* Add ability to skip specific fixers with ``--skip <fixer_name>``
-
-* Add ability to list all possible fixers with ``--list-fixers``
-
-  Thanks to Gav O'Connor in `PR #443 <https://github.com/adamchainz/django-upgrade/pull/443>`__.
-
-  Thanks to David Szotten in `PR #333 <https://github.com/adamchainz/django-upgrade/pull/333>`__.
 
 1.16.0 (2024-02-11)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,39 @@ See the list of available versions with ``django-upgrade --help``.
 Exit with a zero return code even if files have changed.
 By default, django-upgrade uses the failure return code 1 if it changes any files, which may stop scripts or CI pipelines.
 
+Listing Available Fixers
+------------------------
+
+It's possible to list all available fixers using the ``--list-fixers`` flag. All other options will be ignored when listing fixers.
+
+Example:
+
+.. code-block:: sh
+
+    django-upgrade --list-fixers
+
+Only Execute Specific Fixers
+------------------------------
+
+Using the ``--only <fixer_name>`` flag, only the fixer passed in will be executed. Multiple fixers can be chained by using multiple ``--only``
+
+Example:
+
+.. code-block:: sh
+
+    django-upgrade --only admin_allow_tags --only admin_decorators example/core/admin.py
+
+Skip Specific Fixers
+------------------------------
+
+Using the ``--skip <fixer_name>`` flag, all fixers except the ones passed in will be executed. Multiple fixers can be chained by using multiple ``--skip``
+
+Example:
+
+.. code-block:: sh
+
+    django-upgrade --skip admin_register example/core/admin.py
+
 History
 =======
 
@@ -146,6 +179,8 @@ The below fixers run regardless of the target version.
 
 Versioned blocks
 ~~~~~~~~~~~~~~~~
+
+**Name:** ``versioned_branches``
 
 Removes outdated comparisons and blocks from ``if`` statements comparing to ``django.VERSION``.
 Supports comparisons of the form:
@@ -179,6 +214,8 @@ Django 1.7
 
 Admin model registration
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``admin_register``
 
 Rewrites ``admin.site.register()`` calls to the new |@admin.register|_ decorator syntax when eligible.
 This only applies in files that use ``from django.contrib import admin`` or ``from django.contrib.gis import admin``.
@@ -255,6 +292,8 @@ Django 1.9
 ``on_delete`` argument
 ~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``on_delete``
+
 Add ``on_delete=models.CASCADE`` to ``ForeignKey`` and ``OneToOneField``:
 
 .. code-block:: diff
@@ -280,6 +319,8 @@ This fixer also support from-imports:
 ``DATABASES``
 ~~~~~~~~~~~~~
 
+**Name:** ``settings_database_postgresql``
+
 Update the ``DATABASES`` setting backend path ``django.db.backends.postgresql_psycopg2`` to use the renamed version ``django.db.backends.postgresql``.
 
 Settings files are heuristically detected as modules with the whole word “settings” somewhere in their path.
@@ -302,6 +343,8 @@ For example ``myproject/settings.py`` or ``myproject/settings/production.py``.
 Compatibility imports
 ~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``compatibility_imports``
+
 Rewrites some compatibility imports:
 
 * ``django.forms.utils.pretty_name`` in ``django.forms.forms``
@@ -322,6 +365,8 @@ Django 1.10
 
 ``request.user`` boolean attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``request_user_attributes``
 
 Rewrites calls to ``request.user.is_authenticated()`` and ``request.user.is_anonymous()`` to remove the parentheses, per `the deprecation <https://docs.djangoproject.com/en/1.10/releases/1.10/#using-user-is-authenticated-and-user-is-anonymous-as-methods>`__.
 
@@ -363,6 +408,8 @@ Django 1.11
 Compatibility imports
 ~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``compatibility_imports``
+
 Rewrites some compatibility imports:
 
 * ``django.core.exceptions.EmptyResultSet`` in ``django.db.models.query``, ``django.db.models.sql``, and ``django.db.models.sql.datastructures``
@@ -385,6 +432,8 @@ Django 2.0
 
 URL’s
 ~~~~~
+
+**Name:** ``django_urls``
 
 Rewrites imports of ``include()`` and ``url()`` from ``django.conf.urls`` to ``django.urls``.
 ``url()`` calls using compatible regexes are rewritten to the |new path() syntax|_, otherwise they are converted to call ``re_path()``.
@@ -442,6 +491,8 @@ That pattern matches all Unicode word characters, such as “α”, unlike Djang
 ``lru_cache``
 ~~~~~~~~~~~~~
 
+**Name:** ``compatibility_imports``
+
 Rewrites imports of ``lru_cache`` from ``django.utils.functional`` to use ``functools``.
 
 .. code-block:: diff
@@ -461,6 +512,8 @@ Rewrites imports of ``ContextDecorator`` from ``django.utils.decorators`` to use
 
 ``<func>.allow_tags = True``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``admin_allow_tags``
 
 Removes assignments of ``allow_tags`` attributes to ``True``.
 This was an admin feature to allow display functions to return HTML without marking it as unsafe,  deprecated in Django 1.9.
@@ -487,6 +540,8 @@ Django 2.2
 ``HttpRequest.headers``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``request_headers``
+
 Rewrites use of ``request.META`` to read HTTP headers to instead use |request.headers|_.
 Header lookups are done in lowercase per `the HTTP/2 specification <https://httpwg.org/specs/rfc9113.html#HttpHeaders>`__.
 
@@ -510,6 +565,8 @@ Header lookups are done in lowercase per `the HTTP/2 specification <https://http
 ``QuerySetPaginator``
 ~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``queryset_paginator``
+
 Rewrites deprecated alias ``django.core.paginator.QuerySetPaginator`` to ``Paginator``.
 
 .. code-block:: diff
@@ -523,6 +580,8 @@ Rewrites deprecated alias ``django.core.paginator.QuerySetPaginator`` to ``Pagin
 
 ``FixedOffset``
 ~~~~~~~~~~~~~~~
+
+**Name:** ``timezone_fixedoffset``
 
 Rewrites deprecated class ``FixedOffset(x, y))`` to ``timezone(timedelta(minutes=x), y)``
 
@@ -538,6 +597,8 @@ Known limitation: this fixer will leave code broken with an ``ImportError`` if `
 ``FloatRangeField``
 ~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``postgres_float_range_field``
+
 Rewrites model and form fields using ``FloatRangeField`` to ``DecimalRangeField``, from the relevant ``django.contrib.postgres`` modules.
 
 .. code-block:: diff
@@ -552,6 +613,8 @@ Rewrites model and form fields using ``FloatRangeField`` to ``DecimalRangeField`
 
 ``TestCase`` class database declarations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``testcase_databases``
 
 Rewrites the ``allow_database_queries`` and ``multi_db`` attributes of Django’s ``TestCase`` classes to the new ``databases`` attribute.
 This only applies in test files, which are heuristically detected as files with either “test” or “tests” somewhere in their path.
@@ -578,6 +641,8 @@ Django 3.0
 ``django.utils.encoding`` aliases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``utils_encoding``
+
 Rewrites ``smart_text()`` to ``smart_str()``, and ``force_text()`` to ``force_str()``.
 
 .. code-block:: diff
@@ -594,6 +659,8 @@ Rewrites ``smart_text()`` to ``smart_str()``, and ``force_text()`` to ``force_st
 ``django.utils.http`` deprecations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``utils_http``:
+
 Rewrites the ``urlquote()``, ``urlquote_plus()``, ``urlunquote()``, and ``urlunquote_plus()`` functions to the ``urllib.parse`` versions.
 Also rewrites the internal function ``is_safe_url()`` to ``url_has_allowed_host_and_scheme()``.
 
@@ -608,6 +675,8 @@ Also rewrites the internal function ``is_safe_url()`` to ``url_has_allowed_host_
 ``django.utils.text`` deprecation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``utils_text``
+
 Rewrites ``unescape_entities()`` with the standard library ``html.escape()``.
 
 .. code-block:: diff
@@ -620,6 +689,8 @@ Rewrites ``unescape_entities()`` with the standard library ``html.escape()``.
 
 ``django.utils.translation`` deprecations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``utils_translation``
 
 Rewrites the ``ugettext()``, ``ugettext_lazy()``, ``ugettext_noop()``, ``ungettext()``, and ``ungettext_lazy()`` functions to their non-u-prefixed versions.
 
@@ -639,6 +710,8 @@ Django 3.1
 ``JSONField``
 ~~~~~~~~~~~~~
 
+**Name:** ``compatibility_imports``
+
 Rewrites imports of ``JSONField`` and related transform classes from those in ``django.contrib.postgres`` to the new all-database versions.
 Ignores usage in migration files, since Django kept the old class around to support old migrations.
 You will need to make migrations after this fix makes changes to models.
@@ -650,6 +723,8 @@ You will need to make migrations after this fix makes changes to models.
 
 ``PASSWORD_RESET_TIMEOUT_DAYS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``password_reset_timeout_days``
 
 Rewrites the setting ``PASSWORD_RESET_TIMEOUT_DAYS`` to ``PASSWORD_RESET_TIMEOUT``, adding the multiplication by the number of seconds in a day.
 
@@ -664,6 +739,8 @@ For example ``myproject/settings.py`` or ``myproject/settings/production.py``.
 ``Signal``
 ~~~~~~~~~~
 
+**Name:** ``signal_providing_args``
+
 Removes the deprecated documentation-only ``providing_args`` argument.
 
 .. code-block:: diff
@@ -675,6 +752,8 @@ Removes the deprecated documentation-only ``providing_args`` argument.
 ``get_random_string``
 ~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``crypto_get_random_string``
+
 Injects the now-required ``length`` argument, with its previous default ``12``.
 
 .. code-block:: diff
@@ -685,6 +764,8 @@ Injects the now-required ``length`` argument, with its previous default ``12``.
 
 ``NullBooleanField``
 ~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``null_boolean_field``
 
 Transforms the ``NullBooleanField()`` model field to ``BooleanField(null=True)``.
 Applied only in model files, not migration files, since Django kept the old class around to support old migrations.
@@ -702,6 +783,8 @@ You will need to make migrations after this fix makes changes to models.
 ``ModelMultipleChoiceField``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``forms_model_multiple_choice_field``
+
 Replace ``list`` error message key with ``list_invalid`` on forms ``ModelMultipleChoiceField``.
 
 .. code-block:: diff
@@ -716,6 +799,8 @@ Django 3.2
 
 ``@admin.action()``
 ~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``admin_decorators``
 
 Rewrites functions that have admin action attributes assigned to them to use the new |@admin.action decorator|_.
 This only applies in files that use ``from django.contrib import admin`` or ``from django.contrib.gis import admin``.
@@ -753,6 +838,8 @@ This only applies in files that use ``from django.contrib import admin`` or ``fr
 
 ``@admin.display()``
 ~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``admin_decorators``
 
 Rewrites functions that have admin display attributes assigned to them to use the new |@admin.display decorator|_.
 This only applies in files that use ``from django.contrib import admin`` or ``from django.contrib.gis import admin``.
@@ -793,6 +880,8 @@ This only applies in files that use ``from django.contrib import admin`` or ``fr
 ``BaseCommand.requires_system_checks``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``management_commands``
+
 Rewrites the ``requires_system_checks`` attributes of management command classes from bools to ``"__all__"`` or ``[]`` as appropriate.
 This only applies in command files, which are heuristically detected as files with ``management/commands`` somewhere in their path.
 
@@ -811,6 +900,8 @@ This only applies in command files, which are heuristically detected as files wi
 ``EmailValidator``
 ~~~~~~~~~~~~~~~~~~
 
+**Name:** ``email_validator``
+
 Rewrites the ``whitelist`` keyword argument to its new name ``allowlist``.
 
 .. code-block:: diff
@@ -822,6 +913,8 @@ Rewrites the ``whitelist`` keyword argument to its new name ``allowlist``.
 
 ``default_app_config``
 ~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``default_app_config``
 
 Removes module-level ``default_app_config`` assignments from ``__init__.py`` files:
 
@@ -837,6 +930,8 @@ Django 4.0
 ``USE_L10N``
 ~~~~~~~~~~~~
 
+**Name:** ``use_l10n``
+
 Removes the deprecated ``USE_L10N`` setting if set to its default value of ``True``.
 
 Settings files are heuristically detected as modules with the whole word “settings” somewhere in their path.
@@ -848,6 +943,8 @@ For example ``myproject/settings.py`` or ``myproject/settings/production.py``.
 
 ``lookup_needs_distinct``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``admin_lookup_needs_distinct``
 
 Renames the undocumented ``django.contrib.admin.utils.lookup_needs_distinct`` to ``lookup_spawns_duplicates``:
 
@@ -880,6 +977,8 @@ Django 4.1
 ``django.utils.timezone.utc`` deprecations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``utils_timezone``
+
 Rewrites imports of ``django.utils.timezone.utc`` to use ``datetime.timezone.utc``.
 Requires an existing import of the ``datetime`` module.
 
@@ -902,6 +1001,8 @@ Requires an existing import of the ``datetime`` module.
 
 ``assertFormError()`` and ``assertFormsetError()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``assert_form_error``
 
 Rewrites calls to these test case methods from the old signatures to the new ones.
 
@@ -926,6 +1027,8 @@ Django 4.2
 
 ``STORAGES`` setting
 ~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``settings_storages``
 
 Combines deprecated settings ``DEFAULT_FILE_STORAGE`` and ``STATICFILES_STORAGE`` into the new ``STORAGES`` setting, within settings files.
 Only applies if all old settings are defined as strings, at module level, and a ``STORAGES`` setting hasn’t been defined.
@@ -963,6 +1066,8 @@ It then uses ``**`` to extend that with any values in the current module:
 Test client HTTP headers
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Name:** ``test_http_headers``
+
 Transforms HTTP headers from the old WSGI kwarg format to use the new ``headers`` dictionary, for:
 
 * ``Client`` method like ``self.client.get()``
@@ -986,6 +1091,8 @@ Requires Python 3.9+ due to changes in ``ast.keyword``.
 
 ``assertFormsetError`` and ``assertQuerysetEqual``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``assert_set_methods``
 
 Rewrites calls to these test case methods from the old names to the new ones with capitalized “Set”.
 

--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ By default, django-upgrade uses the failure return code 1 if it changes any file
 ``--only <fixer_name>``
 -----------------------
 
-This option makes django-upgrade run only the named fixer (names are documented below).
+Run only the named fixer (names are documented below).
 The fixer must still be enabled by ``--target-version``.
 Select multiple fixers with multiple ``--only`` options.
 
@@ -139,7 +139,7 @@ For example:
 ``--skip <fixer_name>``
 -----------------------
 
-This option makes django-upgrade skip the named fixer.
+Skip the named fixer.
 Skip multiple fixers with multiple ``--skip`` options.
 
 For example:
@@ -151,7 +151,7 @@ For example:
 ``--list-fixers``
 -----------------
 
-This option makes django-upgrade list all available fixers’ names and then exit.
+List all available fixers’ names and then exit.
 All other options are ignored when listing fixers.
 
 For example:

--- a/README.rst
+++ b/README.rst
@@ -123,38 +123,42 @@ See the list of available versions with ``django-upgrade --help``.
 Exit with a zero return code even if files have changed.
 By default, django-upgrade uses the failure return code 1 if it changes any files, which may stop scripts or CI pipelines.
 
-Listing Available Fixers
-------------------------
+``--only <fixer_name>``
+-----------------------
 
-It's possible to list all available fixers using the ``--list-fixers`` flag. All other options will be ignored when listing fixers.
+This option makes django-upgrade run only the named fixer (names are documented below).
+The fixer must still be enabled by ``--target-version``.
+Select multiple fixers with multiple ``--only`` options.
 
-Example:
+For example:
+
+.. code-block:: sh
+
+    django-upgrade --target-version 5.0 --only admin_allow_tags --only admin_decorators example/core/admin.py
+
+``--skip <fixer_name>``
+-----------------------
+
+This option makes django-upgrade skip the named fixer.
+Skip multiple fixers with multiple ``--skip`` options.
+
+For example:
+
+.. code-block:: sh
+
+    django-upgrade --target-version 5.0 --skip admin_register example/core/admin.py
+
+``--list-fixers``
+-----------------
+
+This option makes django-upgrade list all available fixers’ names and then exit.
+All other options are ignored when listing fixers.
+
+For example:
 
 .. code-block:: sh
 
     django-upgrade --list-fixers
-
-Only Execute Specific Fixers
-------------------------------
-
-Using the ``--only <fixer_name>`` flag, only the fixer passed in will be executed. Multiple fixers can be chained by using multiple ``--only``
-
-Example:
-
-.. code-block:: sh
-
-    django-upgrade --only admin_allow_tags --only admin_decorators example/core/admin.py
-
-Skip Specific Fixers
-------------------------------
-
-Using the ``--skip <fixer_name>`` flag, all fixers except the ones passed in will be executed. Multiple fixers can be chained by using multiple ``--skip``
-
-Example:
-
-.. code-block:: sh
-
-    django-upgrade --skip admin_register example/core/admin.py
 
 History
 =======

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -172,11 +172,6 @@ def visit(
     return ret
 
 
-def list_fixers() -> None:
-    for fixer in sorted(FIXERS, key=lambda f: f.name):
-        print(fixer.name)
-
-
 class Fixer:
     __slots__ = (
         "name",

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -166,7 +166,6 @@ def visit(
 class Fixer:
     __slots__ = (
         "name",
-        "module",
         "min_version",
         "ast_funcs",
         "condition",
@@ -174,12 +173,11 @@ class Fixer:
 
     def __init__(
         self,
-        module: str,
+        module_name: str,
         min_version: tuple[int, int],
         condition: Callable[[State], bool] | None = None,
     ) -> None:
-        self.module = module
-        self.name: str = module.rpartition(".")[2]
+        self.name = module_name.rpartition(".")[2]
         self.min_version = min_version
         self.ast_funcs: ASTCallbackMapping = defaultdict(list)
         self.condition = condition

--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -23,22 +23,22 @@ from django_upgrade import fixers
 class Settings:
     __slots__ = (
         "target_version",
-        "specific_fixture_names",
+        "enabled_fixers",
     )
 
     def __init__(
         self,
         target_version: tuple[int, int],
-        only_fixers: list[str] | None = None,
-        skip_fixers: list[str] | None = None,
+        only_fixers: set[str] | None = None,
+        skip_fixers: set[str] | None = None,
     ) -> None:
         self.target_version = target_version
-        self.specific_fixture_names = [
+        self.enabled_fixers = {
             name
             for name in FIXERS
             if (only_fixers is None or name in only_fixers)
             and (skip_fixers is None or name not in skip_fixers)
-        ]
+        }
 
 
 admin_re = re.compile(r"(\b|_)admin(\b|_)")
@@ -213,7 +213,7 @@ _import_fixers()
 def get_ast_funcs(state: State, settings: Settings) -> ASTCallbackMapping:
     ast_funcs: ASTCallbackMapping = defaultdict(list)
     for fixer in FIXERS.values():
-        if fixer.name not in settings.specific_fixture_names:
+        if fixer.name not in settings.enabled_fixers:
             continue
         if fixer.min_version <= state.settings.target_version and (
             fixer.condition is None or fixer.condition(state)

--- a/src/django_upgrade/main.py
+++ b/src/django_upgrade/main.py
@@ -60,16 +60,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--only",
         action="append",
-        help="Only run the selected fixers",
+        help="Run only the selected fixers.",
     )
     parser.add_argument(
         "--skip",
         action="append",
-        help="Skip the selected fixers",
+        help="Skip the selected fixers.",
     )
     parser.add_argument(
-        "--list-fixers",
-        action="store_true",
+        "--list-fixers", action="store_true", help="List all fixer names."
     )
 
     args = parser.parse_args(argv)

--- a/src/django_upgrade/main.py
+++ b/src/django_upgrade/main.py
@@ -83,8 +83,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     settings = Settings(
         target_version=target_version,
-        only_fixers=args.only,
-        skip_fixers=args.skip,
+        only_fixers=set(args.only) if args.only else None,
+        skip_fixers=set(args.skip) if args.skip else None,
     )
 
     ret = 0

--- a/src/django_upgrade/main.py
+++ b/src/django_upgrade/main.py
@@ -61,11 +61,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--only",
         action="append",
+        type=fixer_type,
         help="Run only the selected fixers.",
     )
     parser.add_argument(
         "--skip",
         action="append",
+        type=fixer_type,
         help="Skip the selected fixers.",
     )
     parser.add_argument(
@@ -96,6 +98,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     return ret
 
 
+def fixer_type(string: str) -> str:
+    if string not in FIXERS:
+        raise argparse.ArgumentTypeError(f"Unknown fixer: {string!r}")
+    return string
+
+
 class ListFixersAction(argparse.Action):
     def __call__(
         self,
@@ -104,7 +112,7 @@ class ListFixersAction(argparse.Action):
         values: str | Sequence[Any] | None,
         option_string: str | None = None,
     ) -> None:
-        for name in sorted([f.name for f in FIXERS]):
+        for name in sorted(FIXERS):
             print(name)
         parser.exit()
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -256,12 +256,7 @@ def test_looks_like_test_file_false(filename: str) -> None:
 
 def test_all_fixers_are_documented() -> None:
     readme = (Path(__name__).parent.parent / "README.rst").read_text()
-    docs = set()
-    for line in readme.splitlines():
-        match = re.match(r"\*\*Name:\*\* ``(.+)``", line)
-        if not match:
-            continue
-        docs.add(match[1])
+    docs = {m[1] for m in re.finditer(r"\*\*Name:\*\* ``(.+)``", readme, re.MULTILINE)}
 
     names = set(FIXERS)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -263,10 +263,10 @@ def test_all_fixers_are_documented() -> None:
             continue
         docs.add(match[1])
 
-    fixers = {fixer.name for fixer in FIXERS}
+    names = set(FIXERS)
 
-    invalid = docs - fixers
+    invalid = docs - names
     assert not invalid
 
-    undocumented = fixers - docs
+    undocumented = names - docs
     assert not undocumented

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import re
 from collections import defaultdict
+from pathlib import Path
 
 import pytest
 
+from django_upgrade.data import FIXERS
 from django_upgrade.data import Settings
 from django_upgrade.data import State
 
@@ -249,3 +252,21 @@ def test_looks_like_test_file_true(filename: str) -> None:
 )
 def test_looks_like_test_file_false(filename: str) -> None:
     assert not make_state(filename).looks_like_test_file
+
+
+def test_all_fixers_are_documented() -> None:
+    readme = (Path(__name__).parent.parent / "README.rst").read_text()
+    docs = set()
+    for line in readme.splitlines():
+        match = re.match(r"\*\*Name:\*\* ``(.+)``", line)
+        if not match:
+            continue
+        docs.add(match[1])
+
+    fixers = {fixer.name for fixer in FIXERS}
+
+    invalid = docs - fixers
+    assert not invalid
+
+    undocumented = fixers - docs
+    assert not undocumented


### PR DESCRIPTION
Implements 3 new flags as discussed on [Issue#278](https://github.com/adamchainz/django-upgrade/issues/278). Influenced by davidszotten's previous [PR#333](https://github.com/adamchainz/django-upgrade/pull/333).

- New flag `--skip <fixer_name>` will skip the selected fixer from running.
- New flag `--only <fixer_name>` will only run the selected fixer. 
- Both of the above are repeatable by chaining the flags
- New flag `--list-fixers` will list all available fixers.
- Documentation and Unit test updates

Fixes #278 
