### PR TITLE
Add Model.Meta.index_together fixer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Add Django 4.2+ fixer to rewrite ``index_together`` declarations into ``indexes`` declarations in model ``Meta`` classes.
+
+  `PR #464 <https://github.com/adamchainz/django-upgrade/pull/464>`__.
+
 * Fix tracking of AST node parents.
   This may have fixed some subtle bugs in these fixers:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Changelog
 =========
 
 * Add Django 4.2+ fixer to rewrite ``index_together`` declarations into ``indexes`` declarations in model ``Meta`` classes.
+  This fixer can make changes that require migrations.
+  Add a `test for pending migrations <https://adamj.eu/tech/2024/06/23/django-test-pending-migrations/>`__ to ensure that you do not miss these.
 
   `PR #464 <https://github.com/adamchainz/django-upgrade/pull/464>`__.
 

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,13 @@ For example:
 ``django-upgrade`` focuses on upgrading your code and not on making it look nice.
 Run django-upgrade before formatters like `Black <https://black.readthedocs.io/en/stable/>`__.
 
+Some of django-upgrade’s fixers make changes to models that need migrations:
+
+* ``index_together``
+* ``null_boolean_field``
+
+Add a `test for pending migrations <https://adamj.eu/tech/2024/06/23/django-test-pending-migrations/>`__ to ensure that you do not miss these.
+
 ``django-upgrade`` does not have any ability to recurse through directories.
 Use the pre-commit integration, globbing, or another technique for applying to many files.
 Some fixers depend on the names of containing directories to activate, so ensure you run django-upgrade with paths relative to the root of your project.

--- a/README.rst
+++ b/README.rst
@@ -306,6 +306,23 @@ Requires Python 3.9+ due to changes in ``ast.keyword``.
     -RequestFactory(HTTP_USER_AGENT="curl")
     +RequestFactory(headers={"user-agent": "curl"})
 
+
+``index_together`` deprecation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``index_together``
+
+Rewrites ``index_together`` declarations into ``indexes`` declarations in model ``Meta`` classes.
+
+.. code-block:: diff
+
+     from django.db import models
+
+     class Duck(models.Model):
+         class Meta:
+    -       index_together = [["bill", "tail"]]
+    +       indexes = [models.Index(fields=["bill", "tail"]]
+
 ``assertFormsetError`` and ``assertQuerysetEqual``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/django_upgrade/fixers/index_together.py
+++ b/src/django_upgrade/fixers/index_together.py
@@ -10,6 +10,7 @@ import ast
 from functools import partial
 from typing import Iterable
 
+from tokenize_rt import UNIMPORTANT_WS
 from tokenize_rt import Offset
 from tokenize_rt import Token
 
@@ -18,7 +19,10 @@ from django_upgrade.compat import str_removesuffix
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import DEDENT
+from django_upgrade.tokens import INDENT
 from django_upgrade.tokens import OP
+from django_upgrade.tokens import PHYSICAL_NEWLINE
 from django_upgrade.tokens import erase_node
 from django_upgrade.tokens import extract_indent
 from django_upgrade.tokens import find_last_token
@@ -163,7 +167,12 @@ def extend_indexes(
 ) -> None:
     assert isinstance(indexes.value, (ast.List, ast.Tuple))  # type checked above
     closing_punctuation = find_last_token(tokens, i, node=indexes.value)
-    if len(indexes.value.elts) == 0:
+    if len(indexes.value.elts) == 0 or tokens[closing_punctuation - 1].name in (
+        INDENT,
+        DEDENT,
+        UNIMPORTANT_WS,
+        PHYSICAL_NEWLINE,
+    ):
         prefix = ""
     else:
         j = find_last_token(tokens, i, node=indexes.value.elts[-1])

--- a/src/django_upgrade/fixers/index_together.py
+++ b/src/django_upgrade/fixers/index_together.py
@@ -1,0 +1,126 @@
+"""
+Rewrite Model.Meta.index_together declarations into Model.Meta.Index
+declarations.
+https://docs.djangoproject.com/en/4.2/releases/4.2/#index-together-option-is-deprecated-in-favor-of-indexes
+"""
+
+from __future__ import annotations
+
+import ast
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import erase_node
+from django_upgrade.tokens import find_last_token
+from django_upgrade.tokens import insert
+
+fixer = Fixer(
+    __name__,
+    min_version=(4, 2),
+    condition=lambda state: state.looks_like_models_file,
+)
+
+
+@fixer.register(ast.ClassDef)
+def visit_ClassDef(
+    state: State,
+    node: ast.ClassDef,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if node.name == "Meta" and isinstance(parents[-1], ast.ClassDef):
+        # Find rewritable index_together declaration
+        index_togethers: list[ast.Assign] = []
+        for subnode in node.body:
+            if (
+                isinstance(subnode, ast.Assign)
+                and len(subnode.targets) == 1
+                and isinstance(subnode.targets[0], ast.Name)
+                and subnode.targets[0].id == "index_together"
+                and isinstance(subnode.value, (ast.Tuple, ast.List))
+                and all(
+                    isinstance(elt, (ast.Tuple, ast.List))
+                    and all(
+                        (
+                            isinstance(subelt, ast.Constant)
+                            and isinstance(subelt.value, str)
+                        )
+                        for subelt in elt.elts
+                    )
+                    for elt in subnode.value.elts
+                )
+            ):
+                index_togethers.append(subnode)
+
+        if len(index_togethers) != 1:
+            return
+
+        index_together = index_togethers[0]
+
+        # Optionally find indexes declaration to extend
+        indexeses: list[ast.Assign] = []
+        for subnode in node.body:
+            if (
+                isinstance(subnode, ast.Assign)
+                and len(subnode.targets) == 1
+                and isinstance(subnode.targets[0], ast.Name)
+                and subnode.targets[0].id == "indexes"
+                and isinstance(subnode.value, (ast.Tuple, ast.List))
+            ):
+                indexeses.append(subnode)
+
+        if len(indexeses) > 1:
+            return
+
+        try:
+            indexes = indexeses[0]
+        except IndexError:
+            # TODO: handle none case
+            # indexes = None
+            return
+
+        # TODO: actually generate this, require existing django.db.models import or 'from django.db.models import Index'
+        index_src = "models.Index(fields=[...])"
+
+        yield ast_start_offset(index_together), partial(
+            remove_index_together_and_maybe_add_indexes,
+            index_together=index_together,
+            add_indexes=False,
+            index_src=index_src,
+        )
+        yield ast_start_offset(indexes), partial(
+            extend_indexes, indexes=indexes, index_src=index_src
+        )
+
+
+def remove_index_together_and_maybe_add_indexes(
+    tokens: list[Token],
+    i: int,
+    *,
+    index_together: ast.Assign,
+    add_indexes: bool,
+    index_src: str,
+) -> None:
+    if add_indexes:
+        # TODO
+        pass
+
+    erase_node(tokens, i, node=index_together)
+
+
+def extend_indexes(
+    tokens: list[Token],
+    i: int,
+    *,
+    indexes: ast.Assign,
+    index_src: str,
+) -> None:
+    closing_punctuation = find_last_token(tokens, i, node=indexes.value)
+    # TODO: handle case where indexes has values already with/without trailing comma
+    insert(tokens, closing_punctuation, new_src=index_src)

--- a/src/django_upgrade/fixers/index_together.py
+++ b/src/django_upgrade/fixers/index_together.py
@@ -48,6 +48,10 @@ def visit_ClassDef(
     ):
         return
 
+    # TODO:
+    # For convenience, index_together can be a single list when dealing with a
+    # single set of fields:
+    # index_together = ["pub_date", "deadline"]
     # Find rewritable index_together declaration
     index_togethers: list[ast.Assign] = []
     for subnode in node.body:

--- a/src/django_upgrade/fixers/index_together.py
+++ b/src/django_upgrade/fixers/index_together.py
@@ -42,7 +42,10 @@ def visit_ClassDef(
     node: ast.ClassDef,
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
-    if node.name != "Meta" or not isinstance(parents[-1], ast.ClassDef):
+    if (
+        node.name != "Meta"
+        or sum(isinstance(p, ast.ClassDef) for p in parents[1:]) != 1
+    ):
         return
 
     # Find rewritable index_together declaration

--- a/src/django_upgrade/fixers/index_together.py
+++ b/src/django_upgrade/fixers/index_together.py
@@ -88,9 +88,8 @@ def visit_ClassDef(
 
         if "models" in state.from_imports["django.db"]:
             index_ref = "models.Index"
-        # TODO
-        # elif "Index" in state.from_imports['django.db.models']:
-        #     index_ref = "Index"
+        elif "Index" in state.from_imports["django.db.models"]:
+            index_ref = "Index"
         else:
             return
 

--- a/src/django_upgrade/fixers/index_together.py
+++ b/src/django_upgrade/fixers/index_together.py
@@ -40,7 +40,7 @@ fixer = Fixer(
 def visit_ClassDef(
     state: State,
     node: ast.ClassDef,
-    parents: list[ast.AST],
+    parents: tuple[ast.AST, ...],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
         node.name != "Meta"

--- a/src/django_upgrade/fixers/index_together.py
+++ b/src/django_upgrade/fixers/index_together.py
@@ -45,6 +45,7 @@ def visit_ClassDef(
     if (
         node.name != "Meta"
         or sum(isinstance(p, ast.ClassDef) for p in parents[1:]) != 1
+        or not all(isinstance(subnode, ast.Assign) for subnode in node.body)
     ):
         return
 
@@ -55,9 +56,9 @@ def visit_ClassDef(
     # Find rewritable index_together declaration
     index_togethers: list[ast.Assign] = []
     for subnode in node.body:
+        assert isinstance(subnode, ast.Assign)  # type checked above
         if (
-            isinstance(subnode, ast.Assign)
-            and len(subnode.targets) == 1
+            len(subnode.targets) == 1
             and isinstance(subnode.targets[0], ast.Name)
             and subnode.targets[0].id == "index_together"
             and isinstance(subnode.value, (ast.List, ast.Tuple))
@@ -80,9 +81,9 @@ def visit_ClassDef(
     # Try to find an indexes declaration to extend
     indexeses: list[ast.Assign] = []
     for subnode in node.body:
+        assert isinstance(subnode, ast.Assign)  # type checked above
         if (
-            isinstance(subnode, ast.Assign)
-            and len(subnode.targets) == 1
+            len(subnode.targets) == 1
             and isinstance(subnode.targets[0], ast.Name)
             and subnode.targets[0].id == "indexes"
             and isinstance(subnode.value, (ast.List, ast.Tuple))

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -93,7 +93,7 @@ def find_last_token(tokens: list[Token], i: int, *, node: ast.AST) -> int:
 
 def extract_indent(tokens: list[Token], i: int) -> tuple[int, str]:
     """
-    If the previous token is and indent, return its position and the
+    If the previous token is an indent, return its position and the
     indentation string. Otherwise return the current position and "".
     """
     if i > 0 and tokens[i - 1].name in (INDENT, UNIMPORTANT_WS):

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -207,6 +207,71 @@ def test_mixed_indexes_present():
     )
 
 
+def test_indexes_nonempty_no_trailing_comma():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [("bill", "tail")]
+                indexes = [models.Index("bill")]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index("bill"), models.Index(fields=('bill', 'tail'))]
+        """,
+    )
+
+
+def test_indexes_nonempty_trailing_comma():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [("bill", "tail")]
+                indexes = [models.Index("bill"),]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index("bill"), models.Index(fields=('bill', 'tail'))]
+        """,
+    )
+
+
+def test_indexes_nonempty_multiline():
+    # Leave user’s formatter to sort this out
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [("bill", "tail")]
+                indexes = [
+                    models.Index("bill"),
+                ]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [
+                    models.Index("bill"),
+                 models.Index(fields=('bill', 'tail'))]
+        """,
+    )
+
+
 def test_list_indexes_absent():
     check_transformed(
         """\

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -176,6 +176,26 @@ def test_conditional_indexes():
     )
 
 
+def test_list_single_indexes_present():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = ["bill", "tail"]
+                indexes = []
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=["bill", "tail"])]
+        """,
+    )
+
+
 def test_list_indexes_present():
     check_transformed(
         """\
@@ -204,6 +224,26 @@ def test_tuple_indexes_present():
         class Duck(models.Model):
             class Meta:
                 index_together = [("bill", "tail")]
+                indexes = []
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=("bill", "tail"))]
+        """,
+    )
+
+
+def test_tuple_single_indexes_present():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = ("bill", "tail")
                 indexes = []
         """,
         """\
@@ -375,6 +415,25 @@ def test_indexes_nonempty_multiline_aligned():
     )
 
 
+def test_list_single_indexes_absent():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = ["bill", "tail"]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=["bill", "tail"])]
+        """,
+    )
+
+
 def test_list_indexes_absent():
     check_transformed(
         """\
@@ -390,6 +449,25 @@ def test_list_indexes_absent():
         class Duck(models.Model):
             class Meta:
                 indexes = [models.Index(fields=["bill", "tail"])]
+        """,
+    )
+
+
+def test_tuple_single_indexes_absent():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = ("bill", "tail")
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=("bill", "tail"))]
         """,
     )
 

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -25,7 +25,7 @@ def test_success_indexes_present():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index(fields=["bill", "tail"])]
+                indexes = [models.Index(fields=['bill', 'tail'])]
         """,
         filename="example/models.py",
     )

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -234,8 +234,7 @@ def test_indexes_nonempty_trailing_comma():
     )
 
 
-def test_indexes_nonempty_multiline():
-    # Leave user’s formatter to sort this out
+def test_indexes_nonempty_multiline_dedented():
     check_transformed(
         """\
         from django.db import models
@@ -254,7 +253,79 @@ def test_indexes_nonempty_multiline():
             class Meta:
                 indexes = [
                     models.Index("bill"),
-                 models.Index(fields=("bill", "tail"))]
+                models.Index(fields=("bill", "tail"))]
+        """,
+    )
+
+
+def test_indexes_nonempty_multiline_dedented_fully():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [("bill", "tail")]
+                indexes = [
+                    models.Index("bill"),
+        ]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [
+                    models.Index("bill"),
+        models.Index(fields=("bill", "tail"))]
+        """,
+    )
+
+
+def test_indexes_nonempty_multiline_indented():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [("bill", "tail")]
+                indexes = [
+                    models.Index("bill"),
+                        ]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [
+                    models.Index("bill"),
+                        models.Index(fields=("bill", "tail"))]
+        """,
+    )
+
+
+def test_indexes_nonempty_multiline_aligned():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [("bill", "tail")]
+                indexes = [
+                    models.Index("bill"),
+                    ]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [
+                    models.Index("bill"),
+                    models.Index(fields=("bill", "tail"))]
         """,
     )
 

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -66,7 +66,7 @@ def test_not_sequence():
     )
 
 
-def not_sub_sequence():
+def test_not_sub_sequence():
     check_noop(
         """\
         from django.db import models

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -25,20 +25,6 @@ def test_not_meta_class():
     )
 
 
-def test_not_in_classdef():
-    check_noop(
-        """\
-        from django.db import models
-
-        class Duck(models.Model):
-            if True:
-                class Meta:
-                    index_together = [["bill", "tail"]]
-                    indexes = []
-        """,
-    )
-
-
 def test_no_index_together():
     check_noop(
         """\
@@ -127,6 +113,20 @@ def test_no_models_import():
             class Meta:
                 index_together = [["bill", "tail"]]
                 indexes = []
+        """,
+    )
+
+
+def test_triply_nested():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Quackers:
+            class Duck(models.Model):
+                class Meta:
+                    index_together = [["bill", "tail"]]
+                    indexes = []
         """,
     )
 
@@ -426,5 +426,49 @@ def test_single_quotes_rewritten():
         class Duck:
             class Meta:
                 indexes = [models.Index(fields=["bill", "tail"])]
+        """,
+    )
+
+
+def test_conditional_model_class():
+    check_transformed(
+        """\
+        from django.db import models
+
+        if True:
+            class Duck(models.Model):
+                class Meta:
+                    index_together = [["bill", "tail"]]
+                    indexes = []
+        """,
+        """\
+        from django.db import models
+
+        if True:
+            class Duck(models.Model):
+                class Meta:
+                    indexes = [models.Index(fields=["bill", "tail"])]
+        """,
+    )
+
+
+def test_conditional_meta_class():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            if True:
+                class Meta:
+                    index_together = [["bill", "tail"]]
+                    indexes = []
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            if True:
+                class Meta:
+                    indexes = [models.Index(fields=["bill", "tail"])]
         """,
     )

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from functools import partial
+
+from django_upgrade.data import Settings
+from tests.fixers import tools
+
+settings = Settings(target_version=(4, 2))
+check_noop = partial(tools.check_noop, settings=settings)
+check_transformed = partial(tools.check_transformed, settings=settings)
+
+
+def test_success_indexes_present():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [["bill", "tail"]]
+                indexes = []
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=["bill", "tail"])]
+        """,
+        filename="example/models.py",
+    )

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -131,19 +131,6 @@ def test_no_models_import():
     )
 
 
-def test_index_imported():
-    check_noop(
-        """\
-        from django.db.models import Index
-
-        class Duck:
-            class Meta:
-                index_together = [["bill", "tail"]]
-                indexes = []
-        """,
-    )
-
-
 def test_list_indexes_present():
     check_transformed(
         """\
@@ -328,5 +315,25 @@ def test_mixed_indexes_absent():
         class Duck(models.Model):
             class Meta:
                 indexes = [models.Index(fields=('bill', 'tail')), models.Index(fields=('nape', 'mantle'))]
+        """,
+    )
+
+
+def test_index_imported():
+    check_transformed(
+        """\
+        from django.db.models import Index
+
+        class Duck:
+            class Meta:
+                index_together = [["bill", "tail"]]
+                indexes = []
+        """,
+        """\
+        from django.db.models import Index
+
+        class Duck:
+            class Meta:
+                indexes = [Index(fields=['bill', 'tail'])]
         """,
     )

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -131,6 +131,51 @@ def test_triply_nested():
     )
 
 
+def test_conditional_index_together():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                if something:
+                    index_together = [["bill", "tail"]]
+                else:
+                    index_together = []
+        """,
+    )
+
+
+def test_conditional_index_together_mutation():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = []
+                if something:
+                    index_together.append(["bill", "tail"])
+        """,
+    )
+
+
+def test_conditional_indexes():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [["bill", "tail"]]
+                if something:
+                    indexes = [models.Index(fields=["nape"])]
+                else:
+                    indexes = []
+        """,
+    )
+
+
 def test_list_indexes_present():
     check_transformed(
         """\

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -6,11 +6,145 @@ from django_upgrade.data import Settings
 from tests.fixers import tools
 
 settings = Settings(target_version=(4, 2))
-check_noop = partial(tools.check_noop, settings=settings)
-check_transformed = partial(tools.check_transformed, settings=settings)
+check_noop = partial(tools.check_noop, settings=settings, filename="example/models.py")
+check_transformed = partial(
+    tools.check_transformed, settings=settings, filename="example/models.py"
+)
 
 
-def test_success_indexes_present():
+def test_not_meta_class():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class NotMeta:
+                index_together = [["bill", "tail"]]
+                indexes = []
+        """,
+    )
+
+
+def test_not_in_classdef():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            if True:
+                class Meta:
+                    index_together = [["bill", "tail"]]
+                    indexes = []
+        """,
+    )
+
+
+def test_no_index_together():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [["bill", "tail"]]
+        """,
+    )
+
+
+def test_multiple_index_togethers():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [["bill", "tail"]]
+                index_together = [["tail", "bill"]]
+                indexes = []
+        """,
+    )
+
+
+def test_not_sequence():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = {
+                    ["bill", "tail"]
+                }
+                indexes = []
+        """,
+    )
+
+
+def not_sub_sequence():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [{"bill", "tail"}]
+                indexes = []
+        """,
+    )
+
+
+def test_not_strings():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [[f1, f2]]
+                indexes = []
+        """,
+    )
+
+
+def test_multiple_indexes():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [["bill", "tail"]]
+                indexes = []
+                indexes = []
+        """,
+    )
+
+
+def test_no_models_import():
+    check_noop(
+        """\
+        class Duck:
+            class Meta:
+                index_together = [["bill", "tail"]]
+                indexes = []
+        """,
+    )
+
+
+def test_index_imported():
+    check_noop(
+        """\
+        from django.db.models import Index
+
+        class Duck:
+            class Meta:
+                index_together = [["bill", "tail"]]
+                indexes = []
+        """,
+    )
+
+
+def test_list_indexes_present():
     check_transformed(
         """\
         from django.db import models
@@ -27,5 +161,107 @@ def test_success_indexes_present():
             class Meta:
                 indexes = [models.Index(fields=['bill', 'tail'])]
         """,
-        filename="example/models.py",
+    )
+
+
+def test_tuple_indexes_present():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [("bill", "tail")]
+                indexes = []
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=('bill', 'tail'))]
+        """,
+    )
+
+
+def test_mixed_indexes_present():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [
+                    ("bill", "tail"),
+                    ("nape", "mantle"),
+                ]
+                indexes = []
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=('bill', 'tail')), models.Index(fields=('nape', 'mantle'))]
+        """,
+    )
+
+
+def test_list_indexes_absent():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [["bill", "tail"]]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=['bill', 'tail'])]
+        """,
+    )
+
+
+def test_tuple_indexes_absent():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [("bill", "tail")]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=('bill', 'tail'))]
+        """,
+    )
+
+
+def test_mixed_indexes_absent():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                index_together = [
+                    ("bill", "tail"),
+                    ("nape", "mantle"),
+                ]
+        """,
+        """\
+        from django.db import models
+
+        class Duck(models.Model):
+            class Meta:
+                indexes = [models.Index(fields=('bill', 'tail')), models.Index(fields=('nape', 'mantle'))]
+        """,
     )

--- a/tests/fixers/test_index_together.py
+++ b/tests/fixers/test_index_together.py
@@ -146,7 +146,7 @@ def test_list_indexes_present():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index(fields=['bill', 'tail'])]
+                indexes = [models.Index(fields=["bill", "tail"])]
         """,
     )
 
@@ -166,7 +166,7 @@ def test_tuple_indexes_present():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index(fields=('bill', 'tail'))]
+                indexes = [models.Index(fields=("bill", "tail"))]
         """,
     )
 
@@ -189,7 +189,7 @@ def test_mixed_indexes_present():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index(fields=('bill', 'tail')), models.Index(fields=('nape', 'mantle'))]
+                indexes = [models.Index(fields=("bill", "tail")), models.Index(fields=("nape", "mantle"))]
         """,
     )
 
@@ -209,7 +209,7 @@ def test_indexes_nonempty_no_trailing_comma():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index("bill"), models.Index(fields=('bill', 'tail'))]
+                indexes = [models.Index("bill"), models.Index(fields=("bill", "tail"))]
         """,
     )
 
@@ -229,7 +229,7 @@ def test_indexes_nonempty_trailing_comma():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index("bill"), models.Index(fields=('bill', 'tail'))]
+                indexes = [models.Index("bill"), models.Index(fields=("bill", "tail"))]
         """,
     )
 
@@ -254,7 +254,7 @@ def test_indexes_nonempty_multiline():
             class Meta:
                 indexes = [
                     models.Index("bill"),
-                 models.Index(fields=('bill', 'tail'))]
+                 models.Index(fields=("bill", "tail"))]
         """,
     )
 
@@ -273,7 +273,7 @@ def test_list_indexes_absent():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index(fields=['bill', 'tail'])]
+                indexes = [models.Index(fields=["bill", "tail"])]
         """,
     )
 
@@ -292,7 +292,7 @@ def test_tuple_indexes_absent():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index(fields=('bill', 'tail'))]
+                indexes = [models.Index(fields=("bill", "tail"))]
         """,
     )
 
@@ -314,7 +314,7 @@ def test_mixed_indexes_absent():
 
         class Duck(models.Model):
             class Meta:
-                indexes = [models.Index(fields=('bill', 'tail')), models.Index(fields=('nape', 'mantle'))]
+                indexes = [models.Index(fields=("bill", "tail")), models.Index(fields=("nape", "mantle"))]
         """,
     )
 
@@ -334,6 +334,26 @@ def test_index_imported():
 
         class Duck:
             class Meta:
-                indexes = [Index(fields=['bill', 'tail'])]
+                indexes = [Index(fields=["bill", "tail"])]
+        """,
+    )
+
+
+def test_single_quotes_rewritten():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Duck:
+            class Meta:
+                index_together = [['bill', 'tail']]
+                indexes = []
+        """,
+        """\
+        from django.db import models
+
+        class Duck:
+            class Meta:
+                indexes = [models.Index(fields=["bill", "tail"])]
         """,
     )


### PR DESCRIPTION
Fixes #344.

Handles both forms of `index_together`, in list and tuple, and with/without existing `indexes` definition. Tried to cover every edge case I could think of, per tests.

Tested on Sentry, the only project I could find with historical `index_together` definitions. Use this commit: https://github.com/getsentry/sentry/commit/a32270c8ab84d341d97e15e95e0fa6832ae0a17c, just before github.com/getsentry/sentry/commit/00884d133eaaedf3e69bc8ab3d3bca781e0c425f and later commits updated `index_together`. 

Saw successful rewrites:

```console
$ git ls-files -z '*.py' | xargs -0 django-upgrade --target-version 4.2 --only index_together
Rewriting src/sentry/feedback/models.py
Rewriting src/sentry/incidents/models.py
Rewriting src/sentry/models/activity.py
Rewriting src/sentry/models/artifactbundle.py
Rewriting src/sentry/models/commit.py
Rewriting src/sentry/models/debugfile.py
Rewriting src/sentry/models/eventattachment.py
Rewriting src/sentry/models/group.py
Rewriting src/sentry/models/grouphistory.py
Rewriting src/sentry/models/groupinbox.py
Rewriting src/sentry/models/grouprelease.py
Rewriting src/sentry/models/organizationmembermapping.py
Rewriting src/sentry/models/outbox.py
Rewriting src/sentry/models/pullrequest.py
Rewriting src/sentry/models/release.py
Rewriting src/sentry/models/releasefile.py
Rewriting src/sentry/models/releaseprojectenvironment.py
Rewriting src/sentry/models/rule.py
Rewriting src/sentry/models/statistical_detectors.py
Rewriting src/sentry/models/userreport.py
Rewriting src/sentry/replays/models.py
```

...and the diff looks good:

```diff
$ git diff '*.py' | head -n 50
diff --git src/sentry/feedback/models.py src/sentry/feedback/models.py
index 3527d584bc4..b15d3a8ba45 100644
--- src/sentry/feedback/models.py
+++ src/sentry/feedback/models.py
@@ -27,6 +27,6 @@ class Feedback(Model):
     class Meta:
         app_label = "feedback"
         db_table = "feedback_feedback"
-        index_together = [("project_id", "date_added")]
+        indexes = [models.Index(fields=("project_id", "date_added"))]

     __repr__ = sane_repr("project_id", "feedback_id")
diff --git src/sentry/incidents/models.py src/sentry/incidents/models.py
index 6a4f4f6ae39..06e84dc7136 100644
--- src/sentry/incidents/models.py
+++ src/sentry/incidents/models.py
@@ -205,7 +205,7 @@ class Meta:
         app_label = "sentry"
         db_table = "sentry_incident"
         unique_together = (("organization", "identifier"),)
-        index_together = (("alert_rule", "type", "status"),)
+        indexes = [models.Index(fields=("alert_rule", "type", "status"))]

     @property
     def current_end_date(self):
@@ -561,7 +561,7 @@ class Meta:
         app_label = "sentry"
         db_table = "sentry_incidenttrigger"
         unique_together = (("incident", "alert_rule_trigger"),)
-        index_together = (("alert_rule_trigger", "incident_id"),)
+        indexes = [models.Index(fields=("alert_rule_trigger", "incident_id"))]


 class AlertRuleTriggerManager(BaseManager["AlertRuleTrigger"]):
diff --git src/sentry/models/activity.py src/sentry/models/activity.py
index aa9e0545adc..57575e9ac6b 100644
--- src/sentry/models/activity.py
+++ src/sentry/models/activity.py
@@ -109,7 +109,7 @@ class Activity(Model):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_activity"
-        index_together = (("project", "datetime"),)
+        indexes = [models.Index(fields=("project", "datetime"))]

     __repr__ = sane_repr("project_id", "group_id", "event_id", "user_id", "type", "ident")

diff --git src/sentry/models/artifactbundle.py src/sentry/models/artifactbundle.py
index 323912d6d98..cbfb61c8805 100644
--- src/sentry/models/artifactbundle.py
```

One model was missed due to no `from django.db import models` in the file - I am gonna leave that for extension, if anyone wants.