### PR TITLE
Add format_html() fixer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Add Django 5.0+ fixer to rewrite ``format_html()`` calls without ``args`` or ``kwargs`` probably using ``str.format()`` incorrectly.
+
+  `Issue #477 <https://github.com/adamchainz/django-upgrade/issues/477>`__.
+
 1.20.0 (2024-07-19)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -242,7 +242,24 @@ Django 5.0
 
 `Release Notes <https://docs.djangoproject.com/en/5.0/releases/5.0/>`__
 
-No fixers yet.
+``format_html()`` calls
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``format_html``
+
+Rewrites ``format_html()`` calls without ``args`` or ``kwargs`` but using ``str.format()``.
+Such calls are most likely incorrectly applying formatting without escaping, making them vulnerable to HTML injection.
+Such use cases are why calling ``format_html()`` without any arguments or keyword arguments was deprecated in `Ticket #34609 <https://code.djangoproject.com/ticket/34609>`__.
+
+.. code-block:: diff
+
+     from django.utils.html import format_html
+
+    -format_html("<marquee>{}</marquee>".format(message))
+    +format_html("<marquee>{}</marquee>", message)
+
+    -format_html("<marquee>{name}</marquee>".format(name=name))
+    +format_html("<marquee>{name}</marquee>", name=name)
 
 Django 4.2
 ----------

--- a/src/django_upgrade/fixers/format_html.py
+++ b/src/django_upgrade/fixers/format_html.py
@@ -1,0 +1,73 @@
+"""
+Rewrite some format_html() calls passing formatted strings without other
+arguments or keyword arguments to use the format_html formatting.
+
+https://docs.djangoproject.com/en/5.0/releases/5.0/#features-deprecated-in-5-0
+"""
+
+from __future__ import annotations
+
+import ast
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import alone_on_line
+from django_upgrade.tokens import find
+from django_upgrade.tokens import find_last_token
+from django_upgrade.tokens import insert
+
+fixer = Fixer(
+    __name__,
+    min_version=(5, 0),
+)
+
+
+@fixer.register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parents: tuple[ast.AST, ...],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        "format_html" in state.from_imports["django.utils.html"]
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "format_html"
+        # Template only
+        and len(node.args) == 1
+        and len(node.keywords) == 0
+        # str.format()
+        and isinstance((str_format := node.args[0]), ast.Call)
+        and isinstance(str_format.func, ast.Attribute)
+        and isinstance(str_format.func.value, ast.Constant)
+        and isinstance(str_format.func.value.value, str)
+        and str_format.func.attr == "format"
+    ):
+        yield ast_start_offset(node), partial(rewrite_str_format, node=str_format)
+
+
+def rewrite_str_format(
+    tokens: list[Token],
+    i: int,
+    *,
+    node: ast.Call,
+) -> None:
+    open_start = find(tokens, i, name=OP, src=".")
+    open_end = find(tokens, open_start, name=OP, src="(")
+
+    # closing paren
+    cp_start = cp_end = find_last_token(tokens, open_end, node=node)
+    if alone_on_line(tokens, cp_start, cp_end):
+        cp_start -= 1
+        cp_end += 1
+
+    del tokens[cp_start : cp_end + 1]
+    del tokens[open_start : open_end + 1]
+    insert(tokens, open_start, new_src=", ")

--- a/tests/fixers/test_format_html.py
+++ b/tests/fixers/test_format_html.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from functools import partial
+
+from django_upgrade.data import Settings
+from tests.fixers import tools
+
+settings = Settings(target_version=(5, 0))
+check_noop = partial(tools.check_noop, settings=settings)
+check_transformed = partial(tools.check_transformed, settings=settings)
+
+
+def test_not_imported():
+    check_noop(
+        """\
+        format_html("<marquee>{}</marquee>".format(message))
+        """,
+    )
+
+
+def test_has_arg():
+    check_noop(
+        """\
+        format_html("<marquee>{} {{}}</marquee>".format(message), name)
+        """,
+    )
+
+
+def test_has_kwarg():
+    check_noop(
+        """\
+        format_html("<marquee>{} {{name}}</marquee>".format(message), name=name)
+        """,
+    )
+
+
+def test_variable_format_call():
+    check_noop(
+        """\
+        format_html(template.format(message))
+        """,
+    )
+
+
+def test_int_format_call():
+    check_noop(
+        """\
+        format_html((1).format(message))
+        """,
+    )
+
+
+def test_not_format():
+    check_noop(
+        """\
+        format_html("<marquee>{}</marquee>".fmt(message))
+        """,
+    )
+
+
+def test_pos_arg_single():
+    check_transformed(
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{}</marquee>".format(message))
+        """,
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{}</marquee>", message)
+        """,
+    )
+
+
+def test_pos_arg_double():
+    check_transformed(
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{} {}</marquee>".format(message, name))
+        """,
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{} {}</marquee>", message, name)
+        """,
+    )
+
+
+def test_kwarg_single():
+    check_transformed(
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{m}</marquee>".format(m=message))
+        """,
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{m}</marquee>", m=message)
+        """,
+    )
+
+
+def test_kwarg_double():
+    check_transformed(
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{m} {n}</marquee>".format(m=message, n=name))
+        """,
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{m} {n}</marquee>", m=message, n=name)
+        """,
+    )
+
+
+def test_pos_kwarg_mixed():
+    check_transformed(
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{} {n}</marquee>".format(message, n=name))
+        """,
+        """\
+        from django.utils.html import format_html
+        format_html("<marquee>{} {n}</marquee>", message, n=name)
+        """,
+    )
+
+
+def test_indented():
+    check_transformed(
+        """\
+        from django.utils.html import format_html
+        format_html(
+            "<marquee>{}</marquee>".format(message)
+        )
+        """,
+        """\
+        from django.utils.html import format_html
+        format_html(
+            "<marquee>{}</marquee>", message
+        )
+        """,
+    )
+
+
+def test_indented_double():
+    check_transformed(
+        """\
+        from django.utils.html import format_html
+        format_html(
+            "<marquee>{}</marquee>".format(
+                message
+            )
+        )
+        """,
+        """\
+        from django.utils.html import format_html
+        format_html(
+            "<marquee>{}</marquee>",\x20
+                message
+        )
+        """,
+    )


### PR DESCRIPTION
For #477.

I tried this on a client project with many incorrect `format_html()` calls. I found several examples that the fixer would break, where `format_html()` was used as `mark_safe()`, like:

```python
rows = format_html(...)
table = format_html(
    """
    <table>
        <thead>...</thead>
        <tbody>
            {}
        </tbody>
    </table>
    """.format(
        rows
    )
)
```

The fixer would break this, making `rows` get HTML-escaped.

Since it had more breakage than I expected, I am going to let this one sit. Perhaps it’s not worth adding in the end.