### PR TITLE
Add gis_admin_deprecations fixer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,10 @@ Pending
 
   `PR #660 <https://github.com/adamchainz/django-upgrade/pull/660>`__.
 
+* Add Django 4.0+ fixer :ref:`gis_admin_deprecations <gis_admin_deprecations>` to migrate from deprecated GIS admin classes to the new ones.
+
+  Thanks to Adolfo Fitoria in `PR #484 <https://github.com/adamchainz/django-upgrade/pull/484>`__.
+
 * Extend :ref:`test_http_headers <test_http_headers>` fixer to cover ``AsyncClient``, ``AsyncRequestFactory``, and ``self.async_client.*()`` calls.
 
   Thanks to Benjamin Aduo in `PR #633 <https://github.com/adamchainz/django-upgrade/pull/633>`__.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,7 @@ Pending
 
 * Add Django 4.0+ fixer :ref:`gis_admin_deprecations <gis_admin_deprecations>` to migrate from deprecated GIS admin classes to the new ones.
 
-  Thanks to Adolfo Fitoria in `PR #484 <https://github.com/adamchainz/django-upgrade/pull/484>`__.
+  Thanks to Adolfo Fitoria for the initial implementation in `PR #484 <https://github.com/adamchainz/django-upgrade/pull/484>`__.
 
 * Extend :ref:`test_http_headers <test_http_headers>` fixer to cover ``AsyncClient``, ``AsyncRequestFactory``, and ``self.async_client.*()`` calls.
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -613,6 +613,31 @@ Renames the undocumented ``django.contrib.admin.utils.lookup_needs_distinct`` to
     +if lookup_spawns_duplicates(self.opts, search_spec):
         ...
 
+.. _gis_admin_deprecations:
+
+Deprecated GIS ``ModelAdmin`` classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``gis_admin_deprecations``
+
+Rewrites use of the deprecated classes ``OSMGeoAdmin`` and ``GeoModelAdmin`` to the new ``GISModelAdmin``.
+
+.. code-block:: diff
+
+    -from django.contrib.gis.admin.options import OSMGeoAdmin
+    +from django.contrib.gis.admin.options import GISModelAdmin
+
+    -class MyAdminClass(OSMGeoAdmin):
+    +class MyAdminClass(GISModelAdmin):
+
+.. code-block:: diff
+
+    -from django.contrib.gis.admin.options import GeoModelAdmin
+    +from django.contrib.gis.admin.options import GISModelAdmin
+
+    -class MyAdminClass(GeoModelAdmin):
+    +class MyAdminClass(GISModelAdmin):
+
 Compatibility imports
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/django_upgrade/fixers/gis_admin_deprecations.py
+++ b/src/django_upgrade/fixers/gis_admin_deprecations.py
@@ -1,0 +1,64 @@
+"""
+Migrate from deprecated GIS admin classes to the new ones:
+https://docs.djangoproject.com/en/4.0/releases/4.0/#:~:text=The%20django%2Econtrib%2Egis%2Eadmin%2EGeoModelAdmin
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable
+from functools import partial
+
+from tokenize_rt import Offset
+
+from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
+from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.tokens import find_and_replace_name, update_import_names
+
+fixer = Fixer(
+    __name__,
+    min_version=(4, 0),
+)
+
+MODULE = "django.contrib.gis.admin.options"
+RENAMES = {
+    "OSMGeoAdmin": "GISModelAdmin",
+    "GeoModelAdmin": "GISModelAdmin",
+}
+
+
+@fixer.register(ast.ImportFrom)
+def visit_ImportFrom(
+    state: State,
+    node: ast.ImportFrom,
+    parents: tuple[ast.AST, ...],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if node.module == MODULE and is_rewritable_import_from(node):
+        name_map = {}
+        for alias in node.names:
+            if alias.name in RENAMES:
+                name_map[alias.name] = RENAMES[alias.name]
+
+        if name_map:
+            yield (
+                ast_start_offset(node),
+                partial(
+                    update_import_names,
+                    node=node,
+                    name_map=name_map,
+                ),
+            )
+
+
+@fixer.register(ast.Name)
+def visit_Name(
+    state: State,
+    node: ast.Name,
+    parents: tuple[ast.AST, ...],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (name := node.id) in RENAMES and name in state.from_imports[MODULE]:
+        new_name = RENAMES[name]
+        yield (
+            ast_start_offset(node),
+            partial(find_and_replace_name, name=name, new=new_name),
+        )

--- a/src/django_upgrade/fixers/gis_admin_deprecations.py
+++ b/src/django_upgrade/fixers/gis_admin_deprecations.py
@@ -33,32 +33,127 @@ def visit_ImportFrom(
     node: ast.ImportFrom,
     parents: tuple[ast.AST, ...],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
-    if node.module == MODULE and is_rewritable_import_from(node):
-        name_map = {}
-        for alias in node.names:
-            if alias.name in RENAMES:
-                name_map[alias.name] = RENAMES[alias.name]
+    if node.module != MODULE or not is_rewritable_import_from(node):
+        return
 
-        if name_map:
-            yield (
-                ast_start_offset(node),
-                partial(
-                    update_import_names,
-                    node=node,
-                    name_map=name_map,
-                ),
-            )
+    if len(parents) > 1:  # not a top-level import
+        return
 
+    names_to_rename = {
+        alias.name
+        for alias in node.names
+        if alias.name in RENAMES and alias.asname is None
+    }
+    if not names_to_rename:
+        return
 
-@fixer.register(ast.Name)
-def visit_Name(
-    state: State,
-    node: ast.Name,
-    parents: tuple[ast.AST, ...],
-) -> Iterable[tuple[Offset, TokenFunc]]:
-    if (name := node.id) in RENAMES and name in state.from_imports[MODULE]:
-        new_name = RENAMES[name]
+    module = parents[0]
+    assert isinstance(module, ast.Module)
+
+    name_map: dict[str, str] = {}
+    valid_classes: list[tuple[str, ast.ClassDef]] = []
+
+    for name in names_to_rename:
+        classes, has_other_refs = _find_valid_classes(module, name)
+        if not classes or has_other_refs:
+            continue
+        name_map[name] = RENAMES[name]
+        valid_classes.extend((name, cls) for cls in classes)
+
+    if not name_map:
+        return
+
+    yield (
+        ast_start_offset(node),
+        partial(update_import_names, node=node, name_map=name_map),
+    )
+
+    for name, cls in valid_classes:
+        base = cls.bases[0]
         yield (
-            ast_start_offset(node),
-            partial(find_and_replace_name, name=name, new=new_name),
+            ast_start_offset(base),
+            partial(find_and_replace_name, name=name, new=RENAMES[name]),
         )
+
+
+def _find_valid_classes(
+    module: ast.Module, name: str
+) -> tuple[list[ast.ClassDef], bool]:
+    """
+    Walk the module and return (valid_classes, has_other_refs) for `name`.
+
+    valid_classes: ClassDef nodes whose sole base is `name` and which do not
+    define any GeoModelAdmin-specific attributes.
+    has_other_refs: True if `name` appears as an ast.Name anywhere other than
+    as the sole base of a class in valid_classes.
+    """
+    valid_classes: list[ast.ClassDef] = []
+
+    for node in ast.walk(module):
+        if (
+            isinstance(node, ast.ClassDef)
+            and len(node.bases) == 1
+            and not node.keywords
+            and isinstance(node.bases[0], ast.Name)
+            and node.bases[0].id == name
+            and not _class_defines_bad_attr(node)
+        ):
+            valid_classes.append(node)
+
+    valid_base_ids = {id(cls.bases[0]) for cls in valid_classes}
+    has_other_refs = any(
+        id(node) not in valid_base_ids
+        for node in ast.walk(module)
+        if isinstance(node, ast.Name) and node.id == name
+    )
+    return valid_classes, has_other_refs
+
+
+# Attributes defined by GeoModelAdmin that would be broken by switching to
+# GISModelAdmin, since GISModelAdmin does not support them.
+GEO_MODEL_ADMIN_ATTRS = frozenset(
+    (
+        "debug",
+        "default_lat",
+        "default_lon",
+        "default_zoom",
+        "display_srid",
+        "display_wkt",
+        "extra_js",
+        "layerswitcher",
+        "map_height",
+        "map_srid",
+        "map_template",
+        "map_width",
+        "max_extent",
+        "max_resolution",
+        "max_zoom",
+        "min_zoom",
+        "modifiable",
+        "mouse_position",
+        "num_zoom",
+        "openlayers_url",
+        "point_zoom",
+        "scale_text",
+        "scrollable",
+        "units",
+        "widget",
+        "wms_layer",
+        "wms_name",
+        "wms_options",
+        "wms_url",
+    )
+)
+
+
+def _class_defines_bad_attr(node: ast.ClassDef) -> bool:
+    for stmt in node.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name) and target.id in GEO_MODEL_ADMIN_ATTRS:
+                    return True
+        elif isinstance(stmt, (ast.AnnAssign, ast.AugAssign)):
+            target = stmt.target
+            if isinstance(target, ast.Name) and target.id in GEO_MODEL_ADMIN_ATTRS:
+                return True
+    return False

--- a/tests/fixers/test_gis_admin_deprecations.py
+++ b/tests/fixers/test_gis_admin_deprecations.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from functools import partial
+
+from django_upgrade.data import Settings
+from tests.fixers import tools
+
+settings = Settings(target_version=(4, 0))
+check_noop = partial(tools.check_noop, settings=settings)
+check_transformed = partial(tools.check_transformed, settings=settings)
+
+
+def test_no_deprecated_alias():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import GeoAdmin
+
+        GeoAdmin
+        """,
+    )
+
+
+def test_osm_geo_admin_multiple_inheritance():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin, other):
+            pass
+        """,
+    )
+
+
+def test_osm_geo_admin_overloaded_attribute():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin):
+            default_lon = 1
+        """,
+    )
+
+
+def test_osm_geo_admin_plain():
+    check_transformed(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin):
+            pass
+        """,
+        """\
+        from django.contrib.gis.admin.options import GISModelAdmin
+
+        class MyModelAdmin(GISModelAdmin):
+            pass
+        """,
+    )
+
+
+def test_geo_model_admin_plain():
+    check_transformed(
+        """\
+        from django.contrib.gis.admin.options import GeoModelAdmin
+
+        class MyModelAdmin(GeoModelAdmin):
+            pass
+        """,
+        """\
+        from django.contrib.gis.admin.options import GISModelAdmin
+
+        class MyModelAdmin(GISModelAdmin):
+            pass
+        """,
+    )
+
+
+def test_osm_geo_admin_aliased():
+    check_transformed(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin as GeoAdmin
+
+        class MyModelAdmin(GeoAdmin):
+            pass
+        """,
+        """\
+        from django.contrib.gis.admin.options import GISModelAdmin as GeoAdmin
+
+        class MyModelAdmin(GeoAdmin):
+            pass
+        """,
+    )
+
+
+def test_geo_model_admin_aliased():
+    check_transformed(
+        """\
+        from django.contrib.gis.admin.options import GeoModelAdmin as GeoAdmin
+
+        class MyModelAdmin(GeoAdmin):
+            pass
+        """,
+        """\
+        from django.contrib.gis.admin.options import GISModelAdmin as GeoAdmin
+
+        class MyModelAdmin(GeoAdmin):
+            pass
+        """,
+    )

--- a/tests/fixers/test_gis_admin_deprecations.py
+++ b/tests/fixers/test_gis_admin_deprecations.py
@@ -20,7 +20,82 @@ def test_no_deprecated_alias():
     )
 
 
-def test_osm_geo_admin_multiple_inheritance():
+def test_aliased_import():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin as GeoAdmin
+
+        class MyModelAdmin(GeoAdmin):
+            pass
+        """,
+    )
+
+
+def test_no_class_usage():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+        """,
+    )
+
+
+def test_other_reference():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        x = OSMGeoAdmin
+        """,
+    )
+
+
+def test_other_reference_alongside_valid_class():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin):
+            pass
+
+        x = OSMGeoAdmin
+        """,
+    )
+
+
+def test_non_name_base():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(module.OSMGeoAdmin):
+            pass
+        """,
+    )
+
+
+def test_no_bases():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin():
+            pass
+        """,
+    )
+
+
+def test_keyword_argument():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin, metaclass=Meta):
+            pass
+        """,
+    )
+
+
+def test_multiple_bases():
     check_noop(
         """\
         from django.contrib.gis.admin.options import OSMGeoAdmin
@@ -31,13 +106,81 @@ def test_osm_geo_admin_multiple_inheritance():
     )
 
 
-def test_osm_geo_admin_overloaded_attribute():
+def test_not_a_top_level_import():
+    check_noop(
+        """\
+        if True:
+            from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin):
+            pass
+        """,
+    )
+
+
+def test_overloaded_attribute():
     check_noop(
         """\
         from django.contrib.gis.admin.options import OSMGeoAdmin
 
         class MyModelAdmin(OSMGeoAdmin):
             default_lon = 1
+        """,
+    )
+
+
+def test_overloaded_attribute_annotated():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin):
+            default_lon: int = 1
+        """,
+    )
+
+
+def test_overloaded_attribute_augmented():
+    check_noop(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin):
+            default_lon += 1
+        """,
+    )
+
+
+def test_overloaded_attribute_annotated_non_name_target():
+    check_transformed(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin):
+            self.default_lon: int = 1
+        """,
+        """\
+        from django.contrib.gis.admin.options import GISModelAdmin
+
+        class MyModelAdmin(GISModelAdmin):
+            self.default_lon: int = 1
+        """,
+    )
+
+
+def test_overloaded_attribute_non_name_target():
+    check_transformed(
+        """\
+        from django.contrib.gis.admin.options import OSMGeoAdmin
+
+        class MyModelAdmin(OSMGeoAdmin):
+            self.default_lon = 1
+        """,
+        """\
+        from django.contrib.gis.admin.options import GISModelAdmin
+
+        class MyModelAdmin(GISModelAdmin):
+            self.default_lon = 1
         """,
     )
 
@@ -71,40 +214,6 @@ def test_geo_model_admin_plain():
         from django.contrib.gis.admin.options import GISModelAdmin
 
         class MyModelAdmin(GISModelAdmin):
-            pass
-        """,
-    )
-
-
-def test_osm_geo_admin_aliased():
-    check_transformed(
-        """\
-        from django.contrib.gis.admin.options import OSMGeoAdmin as GeoAdmin
-
-        class MyModelAdmin(GeoAdmin):
-            pass
-        """,
-        """\
-        from django.contrib.gis.admin.options import GISModelAdmin as GeoAdmin
-
-        class MyModelAdmin(GeoAdmin):
-            pass
-        """,
-    )
-
-
-def test_geo_model_admin_aliased():
-    check_transformed(
-        """\
-        from django.contrib.gis.admin.options import GeoModelAdmin as GeoAdmin
-
-        class MyModelAdmin(GeoAdmin):
-            pass
-        """,
-        """\
-        from django.contrib.gis.admin.options import GISModelAdmin as GeoAdmin
-
-        class MyModelAdmin(GeoAdmin):
             pass
         """,
     )


### PR DESCRIPTION
Allows replacement of OSMGeoAdmin and GeoModelAdmin with GISModelAdmin from the same module, those classe were removed on Django 5.0: https://docs.djangoproject.com/en/5.0/releases/5.0/#django-contrib-gis