### PR TITLE
Avoid accidental removal of trailing comments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 
 * Support Python 3.13.
 
+* Avoid accidental removal of comments a removed ``if`` block in the versioned block fixer.
+
+  Thanks to Tobias Funke for the report in `Issue #495 <https://github.com/adamchainz/django-upgrade/issues/495>`__.
+
 1.21.0 (2024-09-05)
 -------------------
 

--- a/src/django_upgrade/fixers/versioned_branches.py
+++ b/src/django_upgrade/fixers/versioned_branches.py
@@ -104,7 +104,7 @@ def _fix_block(
             else_block.dedent(tokens)
             del tokens[if_block.start : else_block.block]
     else:
-        if_block = Block.find(tokens, i)
+        if_block = Block.find(tokens, i, trim_end=True)
         if keep_branch == "first":
             if_block.dedent(tokens)
             del tokens[if_block.start : if_block.block]

--- a/tests/fixers/test_versioned_branches.py
+++ b/tests/fixers/test_versioned_branches.py
@@ -230,7 +230,7 @@ def test_current_version_gt():
     )
 
 
-def test_comment_old_version_lt():
+def test_removed_block_trailing_comment():
     check_transformed(
         """\
         import django
@@ -243,6 +243,23 @@ def test_comment_old_version_lt():
         """\
         import django
 
+
         # test comment
+        """,
+    )
+
+
+def test_removed_block_internal_comment():
+    check_transformed(
+        """\
+        import django
+
+        if django.VERSION < (3, 2):
+            foo()
+            # test comment
+        """,
+        """\
+        import django
+
         """,
     )

--- a/tests/fixers/test_versioned_branches.py
+++ b/tests/fixers/test_versioned_branches.py
@@ -228,3 +228,20 @@ def test_current_version_gt():
         foo()
         """,
     )
+
+def test_comment_old_version_lt():
+    check_transformed(
+        """\
+        import django
+
+        if django.VERSION < (3, 2):
+            foo()
+
+        # test comment
+        """,
+        """\
+        import django
+
+        # test comment
+        """,
+    )

--- a/tests/fixers/test_versioned_branches.py
+++ b/tests/fixers/test_versioned_branches.py
@@ -229,6 +229,7 @@ def test_current_version_gt():
         """,
     )
 
+
 def test_comment_old_version_lt():
     check_transformed(
         """\


### PR DESCRIPTION
We added a test case for the issue mentioned in https://github.com/adamchainz/django-upgrade/issues/495.