### PR TITLE
Support single tuple versioned block fixer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 
 * Support Django 5.2 in ``--target-version``.
 
+* Extend versioned block fixer to support comparisons with single-item tuples, like `django.VERSION >= (4,)`.
+
+  Thanks to Thibaut Decombe in `PR #517 <https://github.com/adamchainz/django-upgrade/pull/517>`__.
+
 1.22.2 (2024-12-02)
 -------------------
 

--- a/src/django_upgrade/ast.py
+++ b/src/django_upgrade/ast.py
@@ -74,7 +74,7 @@ def is_passing_comparison(
         and isinstance(test.ops[0], (ast.Gt, ast.GtE, ast.Lt, ast.LtE))
         and len(test.comparators) == 1
         and isinstance((comparator := test.comparators[0]), ast.Tuple)
-        and len(comparator.elts) == 2
+        and 1 <= len(comparator.elts) <= 2
         and all(isinstance(e, ast.Constant) for e in comparator.elts)
         and all(isinstance(cast(ast.Constant, e).value, int) for e in comparator.elts)
     ):

--- a/tests/fixers/test_versioned_branches.py
+++ b/tests/fixers/test_versioned_branches.py
@@ -10,6 +10,17 @@ check_noop = partial(tools.check_noop, settings=settings)
 check_transformed = partial(tools.check_transformed, settings=settings)
 
 
+def test_empty_tuple():
+    check_noop(
+        """\
+        import django
+
+        if django.VERSION > ():
+            foo()
+        """,
+    )
+
+
 def test_future_version_gt():
     check_noop(
         """\
@@ -261,5 +272,38 @@ def test_removed_block_internal_comment():
         """\
         import django
 
+        """,
+    )
+
+
+def test_old_version_lt_single_tuple():
+    check_transformed(
+        """\
+        import django
+
+        if django.VERSION < (4,):
+            foo()
+        bar()
+        """,
+        """\
+        import django
+
+        bar()
+        """,
+    )
+
+
+def test_current_version_gte_single_tuple():
+    check_transformed(
+        """\
+        import django
+
+        if django.VERSION >= (4,):
+            foo()
+        """,
+        """\
+        import django
+
+        foo()
         """,
     )


### PR DESCRIPTION
Fixes #509 

I intentionally skipped 0-length tuple because it's most likely not intentional and removing code based on that would be surprising I think.