### PR TITLE
Add settings_database_postgresql tests for class-based setting support

### DIFF
--- a/tests/fixers/test_settings_database_postgresql.py
+++ b/tests/fixers/test_settings_database_postgresql.py
@@ -151,3 +151,83 @@ def test_success_with_merged_settings():
         """,
         filename="myapp/settings.py",
     )
+
+
+def test_success_class_based():
+    check_transformed(
+        """\
+        class BaseSettings:
+            DATABASES = {
+                "default": {
+                    "ENGINE": "django.db.backends.postgresql_psycopg2",
+                    "NAME": "mydatabase",
+                    "USER": "mydatabaseuser",
+                    "PASSWORD": "mypassword",
+                    "HOST": "127.0.0.1",
+                    "PORT": "5432",
+                }
+            }
+        """,
+        """\
+        class BaseSettings:
+            DATABASES = {
+                "default": {
+                    "ENGINE": "django.db.backends.postgresql",
+                    "NAME": "mydatabase",
+                    "USER": "mydatabaseuser",
+                    "PASSWORD": "mypassword",
+                    "HOST": "127.0.0.1",
+                    "PORT": "5432",
+                }
+            }
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_success_class_based_inherited():
+    check_transformed(
+        """\
+        class BaseSettings:
+            DATABASES = {
+                "default": {
+                    "ENGINE": "django.db.backends.postgresql_psycopg2",
+                    "NAME": "mydatabase",
+                    "USER": "mydatabaseuser",
+                    "PASSWORD": "mypassword",
+                    "HOST": "127.0.0.1",
+                    "PORT": "5432",
+                }
+            }
+
+        class DevSettings(BaseSettings):
+            DATABASES = {
+                "default": {
+                    "ENGINE": "django.db.backends.sqlite3",
+                    "NAME": "mydatabase",
+                }
+            }
+        """,
+        """\
+        class BaseSettings:
+            DATABASES = {
+                "default": {
+                    "ENGINE": "django.db.backends.postgresql",
+                    "NAME": "mydatabase",
+                    "USER": "mydatabaseuser",
+                    "PASSWORD": "mypassword",
+                    "HOST": "127.0.0.1",
+                    "PORT": "5432",
+                }
+            }
+
+        class DevSettings(BaseSettings):
+            DATABASES = {
+                "default": {
+                    "ENGINE": "django.db.backends.sqlite3",
+                    "NAME": "mydatabase",
+                }
+            }
+        """,
+        filename="myapp/settings.py",
+    )


### PR DESCRIPTION
Fixer already supported class-based settings, so I just added some unittests to cover this scenario.

Partially implements https://github.com/adamchainz/django-upgrade/issues/548