### PR TITLE
Add `--check` option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 
   `PR #579 <https://github.com/adamchainz/django-upgrade/pull/579>`__.
 
+* Add ``--check`` option that only reports which files would be changed.
+
+  Thanks to berzi in `PR #581 <https://github.com/adamchainz/django-upgrade/pull/581>`__.
+
 * Improve stdin handling: exit with code 0 even when changes were made for stdin, and print all other output to stderr.
 
   `PR #583 <https://github.com/adamchainz/django-upgrade/pull/583>`__.

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -23,6 +23,11 @@ __ https://packaging.python.org/en/latest/specifications/pyproject-toml/#depende
 
 If this doesn’t work, ``--target-version`` defaults to 2.2, the oldest supported Django version when django-upgrade was created.
 
+.. option:: --check
+
+Avoid writing any changed files back.
+Instead, exit with a non-zero status code if any files would have been modified, and zero otherwise.
+
 .. option:: --exit-zero-even-if-changed
 
 Exit with a zero return code even if files have changed.
@@ -61,7 +66,3 @@ For example:
 .. code-block:: sh
 
     django-upgrade --list-fixers
-
-.. option:: --check
-
-Show files that would be changed, but don’t modify them.

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -61,3 +61,7 @@ For example:
 .. code-block:: sh
 
     django-upgrade --list-fixers
+
+.. option:: --check
+
+Show files that would be changed, but don’t modify them.

--- a/src/django_upgrade/main.py
+++ b/src/django_upgrade/main.py
@@ -56,6 +56,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="The version of Django to target.",
     )
     parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only output files to change, do not change files.",
+    )
+    parser.add_argument(
         "--exit-zero-even-if-changed",
         action="store_true",
         help="Exit with a zero return code even if files have changed.",
@@ -81,11 +86,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--list-fixers", nargs=0, action=ListFixersAction, help="List all fixer names."
     )
-    parser.add_argument(
-        "--check",
-        action="store_true",
-        help="Only output files to change, do not change files.",
-    )
 
     args = parser.parse_args(argv)
 
@@ -101,7 +101,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             filename,
             settings,
             exit_zero_even_if_changed=args.exit_zero_even_if_changed,
-            write_to_file=not args.check,
+            check=args.check,
         )
 
     return ret
@@ -205,7 +205,7 @@ def fix_file(
     filename: str,
     settings: Settings,
     exit_zero_even_if_changed: bool,
-    write_to_file: bool,
+    check: bool,
 ) -> int:
     if filename == "-":
         contents_bytes = sys.stdin.buffer.read()
@@ -221,19 +221,26 @@ def fix_file(
 
     contents_text = apply_fixers(contents_text, settings, filename)
 
-    if filename == "-":
-        print(contents_text, end="")
-    elif contents_text != contents_text_orig:
-        if write_to_file:
-            print(f"Rewriting {filename}", file=sys.stderr)
-            with open(filename, "w", encoding="UTF-8", newline="") as f:
-                f.write(contents_text)
+    returncode = 0
+    if contents_text != contents_text_orig:
+        if check:
+            display_name = "stdin" if filename == "-" else filename
+            print(f"Would rewrite {display_name}", file=sys.stderr)
+            returncode = 1
         else:
-            print(f"Would rewrite {filename}", file=sys.stderr)
+            if filename == "-":
+                print(contents_text, end="")
+            else:
+                print(f"Rewriting {filename}", file=sys.stderr)
+                with open(filename, "w", encoding="UTF-8", newline="") as f:
+                    f.write(contents_text)
+                if not exit_zero_even_if_changed:
+                    returncode = 1
+    else:
+        if filename == "-" and not check:
+            print(contents_text, end="")
 
-    if exit_zero_even_if_changed or filename == "-":
-        return 0
-    return contents_text != contents_text_orig
+    return returncode
 
 
 def apply_fixers(contents_text: str, settings: Settings, filename: str) -> str:

--- a/src/django_upgrade/main.py
+++ b/src/django_upgrade/main.py
@@ -81,6 +81,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--list-fixers", nargs=0, action=ListFixersAction, help="List all fixer names."
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only output files to change, do not change files.",
+    )
 
     args = parser.parse_args(argv)
 
@@ -96,6 +101,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             filename,
             settings,
             exit_zero_even_if_changed=args.exit_zero_even_if_changed,
+            write_to_file=not args.check,
         )
 
     return ret
@@ -199,6 +205,7 @@ def fix_file(
     filename: str,
     settings: Settings,
     exit_zero_even_if_changed: bool,
+    write_to_file: bool,
 ) -> int:
     if filename == "-":
         contents_bytes = sys.stdin.buffer.read()
@@ -217,9 +224,12 @@ def fix_file(
     if filename == "-":
         print(contents_text, end="")
     elif contents_text != contents_text_orig:
-        print(f"Rewriting {filename}", file=sys.stderr)
-        with open(filename, "w", encoding="UTF-8", newline="") as f:
-            f.write(contents_text)
+        if write_to_file:
+            print(f"Rewriting {filename}", file=sys.stderr)
+            with open(filename, "w", encoding="UTF-8", newline="") as f:
+                f.write(contents_text)
+        else:
+            print(f"Would rewrite {filename}", file=sys.stderr)
 
     if exit_zero_even_if_changed or filename == "-":
         return 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -380,3 +380,22 @@ def test_main_list_fixers_filename(tmp_path, capsys):
     assert excinfo.value.code == 0
     # No change
     assert path.read_text() == source
+
+
+def test_main_check_only(tmp_path, capsys):
+    """
+    Main should not modify files when using --check.
+    """
+
+    initial_contents = "from django.core.paginator import QuerySetPaginator\n"
+    path = tmp_path / "example.py"
+    path.write_text(initial_contents)
+
+    result = main(["--check", str(path)])
+
+    assert result == 1
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == f"Would rewrite {path}\n"
+    # Contents should be unchanged:
+    assert path.read_text() == initial_contents

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,6 +90,34 @@ def test_main_file(tmp_path, capsys):
     assert path.read_text() == "from django.core.paginator import Paginator\n"
 
 
+def test_main_check(tmp_path, capsys):
+    initial_contents = "from django.core.paginator import QuerySetPaginator\n"
+    path = tmp_path / "example.py"
+    path.write_text(initial_contents)
+
+    result = main(["--check", str(path)])
+
+    assert result == 1
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == f"Would rewrite {path}\n"
+    # Contents should be unchanged:
+    assert path.read_text() == initial_contents
+
+
+def test_main_check_stdin(capsys):
+    contents = b"from django.core.paginator import QuerySetPaginator\n"
+    stdin = io.TextIOWrapper(io.BytesIO(contents), "UTF-8")
+
+    with mock.patch.object(sys, "stdin", stdin):
+        result = main(["--check", "-"])
+
+    assert result == 1
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == "Would rewrite stdin\n"
+
+
 def test_main_exit_zero_even_if_changed(tmp_path, capsys):
     path = tmp_path / "example.py"
     path.write_text("from django.core.paginator import QuerySetPaginator\n")
@@ -380,22 +408,3 @@ def test_main_list_fixers_filename(tmp_path, capsys):
     assert excinfo.value.code == 0
     # No change
     assert path.read_text() == source
-
-
-def test_main_check_only(tmp_path, capsys):
-    """
-    Main should not modify files when using --check.
-    """
-
-    initial_contents = "from django.core.paginator import QuerySetPaginator\n"
-    path = tmp_path / "example.py"
-    path.write_text(initial_contents)
-
-    result = main(["--check", str(path)])
-
-    assert result == 1
-    out, err = capsys.readouterr()
-    assert out == ""
-    assert err == f"Would rewrite {path}\n"
-    # Contents should be unchanged:
-    assert path.read_text() == initial_contents


### PR DESCRIPTION
I added a `--check` flag that can be used if one wants to only check whether anything should be upgraded, without immediately changing files. This fits some workflows better than writing to file directly, checking the exit code, then possibly have to revert the changes.

I added documentation and a test for the flag.