### PR TITLE
Fix removing a solo class-based setting

### DIFF
--- a/src/django_upgrade/fixers/settings_forms_urlfield_assume_https.py
+++ b/src/django_upgrade/fixers/settings_forms_urlfield_assume_https.py
@@ -38,6 +38,7 @@ def visit_Assign(
             isinstance(parents[-1], ast.Module)
             or (
                 isinstance(parents[-1], ast.ClassDef)
+                and len(parents[-1].body) > 1
                 and isinstance(parents[-2], ast.Module)
             )
         )

--- a/src/django_upgrade/fixers/use_l10n.py
+++ b/src/django_upgrade/fixers/use_l10n.py
@@ -38,6 +38,7 @@ def visit_Assign(
             isinstance(parents[-1], ast.Module)
             or (
                 isinstance(parents[-1], ast.ClassDef)
+                and len(parents[-1].body) > 1
                 and isinstance(parents[-2], ast.Module)
             )
         )

--- a/tests/fixers/test_settings_forms_urlfield_assume_https.py
+++ b/tests/fixers/test_settings_forms_urlfield_assume_https.py
@@ -103,60 +103,93 @@ def test_success_with_other_lines():
     )
 
 
-def test_success_with_class_based_settings():
-    check_transformed(
+def test_class_not_settings_file():
+    check_noop(
         """\
-        class BaseSettings:
-            SETTINGS_1 = True
+        class Settings:
+            ADMINS = []
             FORMS_URLFIELD_ASSUME_HTTPS = True
-            SETTINGS_2 = True
         """,
-        """\
-        class BaseSettings:
-            SETTINGS_1 = True
-            SETTINGS_2 = True
-        """,
-        filename="myapp/settings/base.py",
     )
 
 
-def test_success_with_class_based_settings_inherited():
-    check_transformed(
+def test_class_false():
+    check_noop(
         """\
-        class BaseSettings:
-            SETTINGS_1 = True
-            FORMS_URLFIELD_ASSUME_HTTPS = True
-
-        class ProdSettings(BaseSettings):
-            SETTINGS_2 = True
-            FORMS_URLFIELD_ASSUME_HTTPS = True
+        class Settings:
+            ADMINS = []
+            FORMS_URLFIELD_ASSUME_HTTPS = False
         """,
-        """\
-        class BaseSettings:
-            SETTINGS_1 = True
-
-        class ProdSettings(BaseSettings):
-            SETTINGS_2 = True
-        """,
-        filename="myapp/settings/base.py",
+        filename="myapp/settings.py",
     )
 
 
-def test_success_with_class_based_configurations():
+def test_class_dynamic():
+    check_noop(
+        """\
+        import os
+        class Settings:
+            ADMINS = []
+            FORMS_URLFIELD_ASSUME_HTTPS = os.environ["FORMS_URLFIELD_ASSUME_HTTPS"]
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_ignore_conditional():
+    check_noop(
+        """\
+        class Settings:
+            ADMINS = []
+            if something:
+                FORMS_URLFIELD_ASSUME_HTTPS = True
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_only_assignment():
+    check_noop(
+        """\
+        class Settings:
+            FORMS_URLFIELD_ASSUME_HTTPS = True
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_success():
     check_transformed(
         """\
-        DEBUG = False
-        FORMS_URLFIELD_ASSUME_HTTPS = True
-
-        class Dev(Configuration):
-            DEBUG = True
+        class Settings:
+            ADMINS = []
             FORMS_URLFIELD_ASSUME_HTTPS = True
         """,
         """\
-        DEBUG = False
+        class Settings:
+            ADMINS = []
+        """,
+        filename="myapp/settings.py",
+    )
 
-        class Dev(Configuration):
-            DEBUG = True
+
+def test_class_success_with_inheritance():
+    check_transformed(
+        """\
+        class BaseSettings:
+            ADMINS = []
+            FORMS_URLFIELD_ASSUME_HTTPS = True
+
+        class ProdSettings(BaseSettings):
+            ADMINS = []
+            FORMS_URLFIELD_ASSUME_HTTPS = True
+        """,
+        """\
+        class BaseSettings:
+            ADMINS = []
+
+        class ProdSettings(BaseSettings):
+            ADMINS = []
         """,
         filename="myapp/settings/base.py",
     )

--- a/tests/fixers/test_use_l10n.py
+++ b/tests/fixers/test_use_l10n.py
@@ -103,60 +103,95 @@ def test_success_with_other_lines():
     )
 
 
-def test_success_with_class_based_settings():
+def test_class_not_settings_file():
+    check_noop(
+        """\
+        class Settings:
+            ADMINS = []
+            USE_L10N = True
+        """,
+    )
+
+
+def test_class_false():
+    check_noop(
+        """\
+        class Settings:
+            ADMINS = []
+            USE_L10N = False
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_dynamic():
+    check_noop(
+        """\
+        import os
+        class Settings:
+            ADMINS = []
+            USE_L10N = os.environ["USE_L10N"]
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_only_assignment():
+    check_noop(
+        """\
+        class Settings:
+            USE_L10N = True
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_ignore_conditional():
+    check_noop(
+        """\
+        class Settings:
+            ADMINS = []
+            if something:
+                USE_L10N = True
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_success():
     check_transformed(
         """\
-        class BaseSettings:
-            SETTINGS_1 = True
+        class Settings:
+            ADMINS = []
             USE_L10N = True
-            SETTINGS_2 = True
+            MANAGERS = []
         """,
         """\
-        class BaseSettings:
-            SETTINGS_1 = True
-            SETTINGS_2 = True
+        class Settings:
+            ADMINS = []
+            MANAGERS = []
         """,
         filename="myapp/settings/base.py",
     )
 
 
-def test_success_with_class_based_settings_inherited():
+def test_class_success_inheritance():
     check_transformed(
         """\
         class BaseSettings:
-            SETTINGS_1 = True
+            ADMINS = []
             USE_L10N = True
 
         class ProdSettings(BaseSettings):
-            SETTINGS_2 = True
+            ADMINS = []
             USE_L10N = True
         """,
         """\
         class BaseSettings:
-            SETTINGS_1 = True
+            ADMINS = []
 
         class ProdSettings(BaseSettings):
-            SETTINGS_2 = True
-        """,
-        filename="myapp/settings/base.py",
-    )
-
-
-def test_success_with_class_based_configurations():
-    check_transformed(
-        """\
-        DEBUG = False
-        USE_L10N = True
-
-        class Dev(Configuration):
-            DEBUG = True
-            USE_L10N = True
-        """,
-        """\
-        DEBUG = False
-
-        class Dev(Configuration):
-            DEBUG = True
+            ADMINS = []
         """,
         filename="myapp/settings/base.py",
     )


### PR DESCRIPTION
Refs #548. Ensure that these two fixers (`settings_forms_urlfield_assume_https` and `use_l10n`) only remove their respective settings from class-based settings classes if there are other statements in the class body. This prevents breaking the code by leaving an empty class definition.

We could still make the fixers work by replacing the body with a `pass` statement, but this is a bit more complex and single-statement classes are probably extremely rare in practice.