### PR TITLE
Add CI check to validate 'uv.lock' is up-to-date

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  uv-lock-check:
+    name: "UV Lockfile Sync Validation 🔒"
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Check uv.lock sync status
+        run: uv lock --locked
+
   tests:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-24.04
+    needs: uv-lock-check
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

This PR adds a **GitHub Actions job** to validate the `uv.lock` file and ensure it is consistent with `pyproject.toml`

## Changes

* Added a new job: **`UV Lockfile Sync Validation 🔒`**

  * Checks `uv.lock` consistency using `uv lock --locked`
* Ensures that CI fails if the lockfile is out of sync.

## Benefits

* Prevents **out-of-sync dependencies** from entering the codebase.
* Improves **CI reliability** by catching lockfile issues early.
* Maintains **consistent environment** across all contributors and CI runners.

## How to Test / Verify

1. Push changes to a branch with an **outdated `uv.lock`**.
2. Observe that the CI **fails the lockfile check**.
3. Update the lockfile with `uv lock` and verify that CI passes.