### PR TITLE
Extend `utils_timezone` fixer work when no datetime import exists

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,10 @@ Pending
 
   Thanks to Benjamin Aduo in `PR #633 <https://github.com/adamchainz/django-upgrade/pull/633>`__.
 
+* Extend :ref:`utils_timezone` fixer to work when no ``import datetime`` statement exists, by inserting ``import datetime as dt`` when the name ``dt`` is unused.
+
+  Thanks to Ryan Siemens for the report in `Issue #568 <https://github.com/adamchainz/django-upgrade/issues/568>`__ and Benjamin Aduo for the implementation in `PR #631 <https://github.com/adamchainz/django-upgrade/pull/631>`__.
+
 * Extend :ref:`versioned_test_skip_decorators <versioned_test_skip_decorators>` fixer to also remove the entire decorated function or class when the skip condition is always true.
   For example, when targeting Django 5.2+, a function decorated with ``@pytest.mark.skipif(django.VERSION >= (5, 2), ...)`` will be removed.
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -471,6 +471,8 @@ Django 4.1
 
 `Release Notes <https://docs.djangoproject.com/en/4.1/releases/4.1/>`__
 
+.. _utils_timezone:
+
 ``django.utils.timezone.utc`` deprecations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -479,7 +479,7 @@ Django 4.1
 **Name:** ``utils_timezone``
 
 Rewrites imports of ``django.utils.timezone.utc`` to use ``datetime.timezone.utc``.
-Requires an existing import of the ``datetime`` module, or that the name ``dt`` is unused, in which case ``import datetime as dt`` is inserted.
+Uses an existing ``import datetime`` statement if present, otherwise inserts ``import datetime as dt`` if the name ``dt`` is unused in the module.
 
 .. code-block:: diff
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -477,7 +477,7 @@ Django 4.1
 **Name:** ``utils_timezone``
 
 Rewrites imports of ``django.utils.timezone.utc`` to use ``datetime.timezone.utc``.
-Requires an existing import of the ``datetime`` module.
+Requires an existing import of the ``datetime`` module, or that the name ``dt`` is unused, in which case ``import datetime as dt`` is inserted.
 
 .. code-block:: diff
 
@@ -495,6 +495,15 @@ Requires an existing import of the ``datetime`` module.
 
     -do_a_thing(timezone.utc)
     +do_a_thing(dt.timezone.utc)
+
+.. code-block:: diff
+
+    +import datetime as dt
+     from datetime import datetime
+     from django.utils import timezone
+
+    -do_a_thing(datetime.now(tz=timezone.utc))
+    +do_a_thing(datetime.now(tz=dt.timezone.utc))
 
 ``assertFormError()`` and ``assertFormsetError()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/django_upgrade/ast.py
+++ b/src/django_upgrade/ast.py
@@ -3,11 +3,37 @@ from __future__ import annotations
 import ast
 import warnings
 from typing import TYPE_CHECKING, Literal, cast
+from weakref import WeakKeyDictionary
 
 from tokenize_rt import Offset
 
 if TYPE_CHECKING:
     from django_upgrade.data import State
+
+
+_module_names: WeakKeyDictionary[ast.Module, frozenset[str]] = WeakKeyDictionary()
+
+
+def get_module_names(module: ast.Module) -> frozenset[str]:
+    try:
+        return _module_names[module]
+    except KeyError:
+        pass
+
+    names: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.alias):
+            names.add(node.asname if node.asname is not None else node.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.arg):
+            names.add(node.arg)
+
+    result = frozenset(names)
+    _module_names[module] = result
+    return result
 
 
 def ast_parse(contents_text: str) -> ast.Module:

--- a/src/django_upgrade/fixers/utils_timezone.py
+++ b/src/django_upgrade/fixers/utils_timezone.py
@@ -87,9 +87,10 @@ def _is_name_used(module: ast.Module, name: str) -> bool:
     for node in ast.walk(module):
         if isinstance(node, ast.Name) and node.id == name:
             return True
-        if isinstance(node, ast.alias):
-            if node.asname == name or (node.asname is None and node.name == name):
-                return True
+        if isinstance(node, ast.alias) and (
+            node.asname == name or (node.asname is None and node.name == name)
+        ):
+            return True
         if (
             isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
             and node.name == name

--- a/src/django_upgrade/fixers/utils_timezone.py
+++ b/src/django_upgrade/fixers/utils_timezone.py
@@ -10,11 +10,11 @@ from collections.abc import Iterable, MutableMapping
 from functools import partial
 from weakref import WeakKeyDictionary
 
-from tokenize_rt import Offset
+from tokenize_rt import Offset, Token
 
 from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
 from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import replace, update_import_names
+from django_upgrade.tokens import extract_indent, insert, replace, update_import_names
 
 fixer = Fixer(
     __name__,
@@ -36,6 +36,7 @@ def visit_Name(
         )
         and details.datetime_module is not None
     ):
+        yield from maybe_add_datetime_import(details)
         yield from maybe_rewrite_import(details)
         new_src = f"{details.datetime_module}.timezone.utc"
         yield ast_start_offset(node), partial(replace, src=new_src)
@@ -55,6 +56,7 @@ def visit_Attribute(
         and (details := get_import_details(state, parents[0])).datetime_module
         is not None
     ):
+        yield from maybe_add_datetime_import(details)
         new_src = f"{details.datetime_module}.timezone"
         yield ast_start_offset(node), partial(replace, src=new_src)
 
@@ -64,15 +66,37 @@ class ImportDetails:
         "old_utc_import",
         "datetime_module",
         "rewrite_scheduled",
+        "first_import_node",
+        "needs_datetime_import",
+        "add_import_scheduled",
     )
 
     def __init__(self) -> None:
         self.old_utc_import: ast.ImportFrom | None = None
         self.datetime_module: str | None = None
         self.rewrite_scheduled = False
+        self.first_import_node: ast.Import | ast.ImportFrom | None = None
+        self.needs_datetime_import = False
+        self.add_import_scheduled = False
 
 
 import_details: MutableMapping[State, ImportDetails] = WeakKeyDictionary()
+
+
+def _is_name_used(module: ast.Module, name: str) -> bool:
+    for node in ast.walk(module):
+        if isinstance(node, ast.Name) and node.id == name:
+            return True
+        if isinstance(node, ast.alias):
+            if node.asname == name or (node.asname is None and node.name == name):
+                return True
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ) and node.name == name:
+            return True
+        if isinstance(node, ast.arg) and node.arg == name:
+            return True
+    return False
 
 
 def get_import_details(state: State, module: ast.AST) -> ImportDetails:
@@ -96,6 +120,9 @@ def get_import_details(state: State, module: ast.AST) -> ImportDetails:
         if not isinstance(node, (ast.Import, ast.ImportFrom)):
             break
 
+        if details.first_import_node is None:
+            details.first_import_node = node
+
         if isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name == "datetime":
@@ -113,8 +140,34 @@ def get_import_details(state: State, module: ast.AST) -> ImportDetails:
         ):
             details.old_utc_import = node
 
+    if details.datetime_module is None and not _is_name_used(module, "dt"):
+        details.datetime_module = "dt"
+        details.needs_datetime_import = True
+
     import_details[state] = details
     return details
+
+
+def add_datetime_import(
+    tokens: list[Token], i: int, *, dt_alias: str
+) -> None:
+    j, indent = extract_indent(tokens, i)
+    insert(tokens, j, new_src=f"{indent}import datetime as {dt_alias}\n")
+
+
+def maybe_add_datetime_import(
+    details: ImportDetails,
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if not details.needs_datetime_import or details.add_import_scheduled:
+        return
+
+    assert details.first_import_node is not None
+    yield (
+        ast_start_offset(details.first_import_node),
+        partial(add_datetime_import, dt_alias="dt"),
+    )
+
+    details.add_import_scheduled = True
 
 
 def maybe_rewrite_import(

--- a/src/django_upgrade/fixers/utils_timezone.py
+++ b/src/django_upgrade/fixers/utils_timezone.py
@@ -90,9 +90,10 @@ def _is_name_used(module: ast.Module, name: str) -> bool:
         if isinstance(node, ast.alias):
             if node.asname == name or (node.asname is None and node.name == name):
                 return True
-        if isinstance(
-            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
-        ) and node.name == name:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+            and node.name == name
+        ):
             return True
         if isinstance(node, ast.arg) and node.arg == name:
             return True
@@ -148,9 +149,7 @@ def get_import_details(state: State, module: ast.AST) -> ImportDetails:
     return details
 
 
-def add_datetime_import(
-    tokens: list[Token], i: int, *, dt_alias: str
-) -> None:
+def add_datetime_import(tokens: list[Token], i: int, *, dt_alias: str) -> None:
     j, indent = extract_indent(tokens, i)
     insert(tokens, j, new_src=f"{indent}import datetime as {dt_alias}\n")
 

--- a/src/django_upgrade/fixers/utils_timezone.py
+++ b/src/django_upgrade/fixers/utils_timezone.py
@@ -18,7 +18,13 @@ from django_upgrade.ast import (
     is_rewritable_import_from,
 )
 from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import extract_indent, insert, replace, update_import_names
+from django_upgrade.tokens import (
+    extract_indent,
+    find_first_token,
+    insert,
+    replace,
+    update_import_names,
+)
 
 fixer = Fixer(
     __name__,
@@ -40,8 +46,7 @@ def visit_Name(
         )
         and details.datetime_module is not None
     ):
-        yield from maybe_add_datetime_import(details)
-        yield from maybe_rewrite_import(details)
+        yield from maybe_rewrite_imports(details, erase=True)
         new_src = f"{details.datetime_module}.timezone.utc"
         yield ast_start_offset(node), partial(replace, src=new_src)
 
@@ -60,7 +65,7 @@ def visit_Attribute(
         and (details := get_import_details(state, parents[0])).datetime_module
         is not None
     ):
-        yield from maybe_add_datetime_import(details)
+        yield from maybe_rewrite_imports(details, erase=False)
         new_src = f"{details.datetime_module}.timezone"
         yield ast_start_offset(node), partial(replace, src=new_src)
 
@@ -136,40 +141,47 @@ def get_import_details(state: State, module: ast.AST) -> ImportDetails:
     return details
 
 
-def add_datetime_import(tokens: list[Token], i: int, *, dt_alias: str) -> None:
-    j, indent = extract_indent(tokens, i)
-    insert(tokens, j, new_src=f"{indent}import datetime as {dt_alias}\n")
-
-
-def maybe_add_datetime_import(
+def maybe_rewrite_imports(
     details: ImportDetails,
+    *,
+    erase: bool,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
-    if not details.needs_datetime_import or details.add_import_scheduled:
+    do_insert = details.needs_datetime_import and not details.add_import_scheduled
+    do_erase = erase and not details.rewrite_scheduled
+
+    if not do_insert and not do_erase:
         return
 
     assert details.first_import_node is not None
     yield (
         ast_start_offset(details.first_import_node),
-        partial(add_datetime_import, dt_alias="dt"),
-    )
-
-    details.add_import_scheduled = True
-
-
-def maybe_rewrite_import(
-    details: ImportDetails,
-) -> Iterable[tuple[Offset, TokenFunc]]:
-    if details.rewrite_scheduled:
-        return
-
-    assert details.old_utc_import is not None
-    yield (
-        ast_start_offset(details.old_utc_import),
         partial(
-            update_import_names,
+            rewrite_imports,
             node=details.old_utc_import,
-            name_map={"utc": ""},
+            insert_dt=do_insert,
+            erase_utc=do_erase,
         ),
     )
 
-    details.rewrite_scheduled = True
+    if do_insert:
+        details.add_import_scheduled = True
+    if do_erase:
+        details.rewrite_scheduled = True
+
+
+def rewrite_imports(
+    tokens: list[Token],
+    i: int,
+    *,
+    node: ast.ImportFrom | None,
+    insert_dt: bool,
+    erase_utc: bool,
+) -> None:
+    if insert_dt:
+        j, indent = extract_indent(tokens, i)
+        insert(tokens, j, new_src=f"{indent}import datetime as dt\n")
+        i += 1
+    if erase_utc:
+        assert node is not None
+        i = find_first_token(tokens, i, node=node)
+        update_import_names(tokens, i, node=node, name_map={"utc": ""})

--- a/src/django_upgrade/fixers/utils_timezone.py
+++ b/src/django_upgrade/fixers/utils_timezone.py
@@ -12,7 +12,11 @@ from weakref import WeakKeyDictionary
 
 from tokenize_rt import Offset, Token
 
-from django_upgrade.ast import ast_start_offset, is_rewritable_import_from
+from django_upgrade.ast import (
+    ast_start_offset,
+    get_module_names,
+    is_rewritable_import_from,
+)
 from django_upgrade.data import Fixer, State, TokenFunc
 from django_upgrade.tokens import extract_indent, insert, replace, update_import_names
 
@@ -83,24 +87,6 @@ class ImportDetails:
 import_details: MutableMapping[State, ImportDetails] = WeakKeyDictionary()
 
 
-def _is_name_used(module: ast.Module, name: str) -> bool:
-    for node in ast.walk(module):
-        if isinstance(node, ast.Name) and node.id == name:
-            return True
-        if isinstance(node, ast.alias) and (
-            node.asname == name or (node.asname is None and node.name == name)
-        ):
-            return True
-        if (
-            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
-            and node.name == name
-        ):
-            return True
-        if isinstance(node, ast.arg) and node.arg == name:
-            return True
-    return False
-
-
 def get_import_details(state: State, module: ast.AST) -> ImportDetails:
     assert isinstance(module, ast.Module)
     try:
@@ -142,7 +128,7 @@ def get_import_details(state: State, module: ast.AST) -> ImportDetails:
         ):
             details.old_utc_import = node
 
-    if details.datetime_module is None and not _is_name_used(module, "dt"):
+    if details.datetime_module is None and "dt" not in get_module_names(module):
         details.datetime_module = "dt"
         details.needs_datetime_import = True
 

--- a/tests/fixers/test_utils_timezone.py
+++ b/tests/fixers/test_utils_timezone.py
@@ -42,11 +42,17 @@ def test_import_used_otherwise():
 
 
 def test_no_datetime_import():
-    check_noop(
+    check_transformed(
         """\
         from django.utils import timezone
 
         do_a_thing(timezone.utc)
+        """,
+        """\
+        import datetime as dt
+        from django.utils import timezone
+
+        do_a_thing(dt.timezone.utc)
         """,
     )
 
@@ -217,6 +223,52 @@ def test_attr_import_aliased():
         """\
         import datetime as dt
         from django.utils import timezone
+
+        do_a_thing(dt.timezone.utc)
+        """,
+    )
+
+
+def test_no_datetime_import_dt_name_conflict():
+    check_noop(
+        """\
+        from django.utils import timezone
+
+        dt = timezone.now()
+        do_a_thing(timezone.utc)
+        """,
+    )
+
+
+def test_from_datetime_import_attr():
+    check_transformed(
+        """\
+        from datetime import datetime
+        from django.utils import timezone
+
+        do_a_thing(datetime.now(tz=timezone.utc))
+        """,
+        """\
+        import datetime as dt
+        from datetime import datetime
+        from django.utils import timezone
+
+        do_a_thing(datetime.now(tz=dt.timezone.utc))
+        """,
+    )
+
+
+def test_from_datetime_import_name():
+    check_transformed(
+        """\
+        from datetime import datetime
+        from django.utils.timezone import utc
+
+        do_a_thing(utc)
+        """,
+        """\
+        import datetime as dt
+        from datetime import datetime
 
         do_a_thing(dt.timezone.utc)
         """,

--- a/tests/fixers/test_utils_timezone.py
+++ b/tests/fixers/test_utils_timezone.py
@@ -41,22 +41,6 @@ def test_import_used_otherwise():
     )
 
 
-def test_no_datetime_import():
-    check_transformed(
-        """\
-        from django.utils import timezone
-
-        do_a_thing(timezone.utc)
-        """,
-        """\
-        import datetime as dt
-        from django.utils import timezone
-
-        do_a_thing(dt.timezone.utc)
-        """,
-    )
-
-
 def test_attr_no_import():
     check_noop(
         """\
@@ -75,6 +59,17 @@ def test_not_imported_utc_name():
     )
 
 
+def test_no_datetime_import_dt_name_conflict():
+    check_noop(
+        """\
+        from django.utils import timezone
+
+        dt = timezone.now()
+        do_a_thing(timezone.utc)
+        """,
+    )
+
+
 def test_basic():
     check_transformed(
         """\
@@ -83,38 +78,6 @@ def test_basic():
         do_a_thing(utc)
         """,
         """\
-        import datetime
-        do_a_thing(datetime.timezone.utc)
-        """,
-    )
-
-
-def test_other_imports():
-    check_transformed(
-        """\
-        import datetime
-        from django.utils.timezone import utc
-        from myapp import timezone
-        do_a_thing(utc)
-        """,
-        """\
-        import datetime
-        from myapp import timezone
-        do_a_thing(datetime.timezone.utc)
-        """,
-    )
-
-
-def test_docstring():
-    check_transformed(
-        """\
-        '''my module'''
-        from django.utils.timezone import utc
-        import datetime
-        do_a_thing(utc)
-        """,
-        """\
-        '''my module'''
         import datetime
         do_a_thing(datetime.timezone.utc)
         """,
@@ -163,6 +126,38 @@ def test_import_paired_alias():
     )
 
 
+def test_docstring():
+    check_transformed(
+        """\
+        '''my module'''
+        from django.utils.timezone import utc
+        import datetime
+        do_a_thing(utc)
+        """,
+        """\
+        '''my module'''
+        import datetime
+        do_a_thing(datetime.timezone.utc)
+        """,
+    )
+
+
+def test_other_imports():
+    check_transformed(
+        """\
+        import datetime
+        from django.utils.timezone import utc
+        from myapp import timezone
+        do_a_thing(utc)
+        """,
+        """\
+        import datetime
+        from myapp import timezone
+        do_a_thing(datetime.timezone.utc)
+        """,
+    )
+
+
 def test_multiple():
     check_transformed(
         """\
@@ -191,6 +186,23 @@ def test_fix_skips_other_utc_names():
         import datetime as dt
         dt.timezone.utc
         myobj.utc
+        """,
+    )
+
+
+def test_from_datetime_import_name():
+    check_transformed(
+        """\
+        from datetime import datetime
+        from django.utils.timezone import utc
+
+        do_a_thing(utc)
+        """,
+        """\
+        import datetime as dt
+        from datetime import datetime
+
+        do_a_thing(dt.timezone.utc)
         """,
     )
 
@@ -229,13 +241,18 @@ def test_attr_import_aliased():
     )
 
 
-def test_no_datetime_import_dt_name_conflict():
-    check_noop(
+def test_no_datetime_import():
+    check_transformed(
         """\
         from django.utils import timezone
 
-        dt = timezone.now()
         do_a_thing(timezone.utc)
+        """,
+        """\
+        import datetime as dt
+        from django.utils import timezone
+
+        do_a_thing(dt.timezone.utc)
         """,
     )
 
@@ -254,22 +271,5 @@ def test_from_datetime_import_attr():
         from django.utils import timezone
 
         do_a_thing(datetime.now(tz=dt.timezone.utc))
-        """,
-    )
-
-
-def test_from_datetime_import_name():
-    check_transformed(
-        """\
-        from datetime import datetime
-        from django.utils.timezone import utc
-
-        do_a_thing(utc)
-        """,
-        """\
-        import datetime as dt
-        from datetime import datetime
-
-        do_a_thing(dt.timezone.utc)
         """,
     )

--- a/tests/fixers/test_utils_timezone.py
+++ b/tests/fixers/test_utils_timezone.py
@@ -190,6 +190,37 @@ def test_fix_skips_other_utc_names():
     )
 
 
+def test_no_datetime_import_name():
+    check_transformed(
+        """\
+        from django.utils.timezone import utc
+
+        do_a_thing(utc)
+        """,
+        """\
+        import datetime as dt
+
+        do_a_thing(dt.timezone.utc)
+        """,
+    )
+
+
+def test_no_datetime_import_name_multiname():
+    check_transformed(
+        """\
+        from django.utils.timezone import utc, now
+
+        do_a_thing(utc)
+        """,
+        """\
+        import datetime as dt
+        from django.utils.timezone import now
+
+        do_a_thing(dt.timezone.utc)
+        """,
+    )
+
+
 def test_from_datetime_import_name():
     check_transformed(
         """\
@@ -253,6 +284,82 @@ def test_no_datetime_import():
         from django.utils import timezone
 
         do_a_thing(dt.timezone.utc)
+        """,
+    )
+
+
+def test_attr_multiple_no_datetime_import():
+    check_transformed(
+        """\
+        from django.utils import timezone
+
+        do_a_thing(timezone.utc)
+        do_a_thing(timezone.utc)
+        """,
+        """\
+        import datetime as dt
+        from django.utils import timezone
+
+        do_a_thing(dt.timezone.utc)
+        do_a_thing(dt.timezone.utc)
+        """,
+    )
+
+
+def test_name_and_attr_no_datetime_import():
+    check_transformed(
+        """\
+        from django.utils.timezone import utc
+        from django.utils import timezone
+
+        do_a_thing(utc)
+        do_a_thing(timezone.utc)
+        """,
+        """\
+        import datetime as dt
+        from django.utils import timezone
+
+        do_a_thing(dt.timezone.utc)
+        do_a_thing(dt.timezone.utc)
+        """,
+    )
+
+
+def test_attr_and_name_no_datetime_import():
+    check_transformed(
+        """\
+        from django.utils.timezone import utc
+        from django.utils import timezone
+
+        do_a_thing(timezone.utc)
+        do_a_thing(utc)
+        """,
+        """\
+        import datetime as dt
+        from django.utils import timezone
+
+        do_a_thing(dt.timezone.utc)
+        do_a_thing(dt.timezone.utc)
+        """,
+    )
+
+
+def test_name_and_attr():
+    check_transformed(
+        """\
+        import datetime
+        from django.utils.timezone import utc
+        from django.utils import timezone
+
+        do_a_thing(utc)
+        do_a_thing(timezone.utc)
+        """,
+        """\
+        import datetime
+        from django.utils import timezone
+
+        do_a_thing(datetime.timezone.utc)
+        do_a_thing(datetime.timezone.utc)
         """,
     )
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from django_upgrade.ast import get_module_names
+
+
+class TestGetModuleNames:
+    def names(self, src: str) -> frozenset[str]:
+        return get_module_names(ast.parse(src))
+
+    @pytest.mark.parametrize(
+        "src",
+        (
+            "x",
+            "x = 1",
+            "del x",
+        ),
+    )
+    def test_name(self, src: str) -> None:
+        assert self.names(src) == frozenset({"x"})
+
+    @pytest.mark.parametrize(
+        "src",
+        (
+            "import x",
+            "import y as x",
+            "from m import x",
+            "from m import y as x",
+        ),
+    )
+    def test_alias(self, src: str) -> None:
+        assert self.names(src) == frozenset({"x"})
+
+    def test_function_def(self) -> None:
+        assert self.names("def x(): pass") == frozenset({"x"})
+
+    def test_async_function_def(self) -> None:
+        assert self.names("async def x(): pass") == frozenset({"x"})
+
+    def test_class_def(self) -> None:
+        assert self.names("class x: pass") == frozenset({"x"})
+
+    def test_arg(self) -> None:
+        assert self.names("def f(x): pass") == frozenset({"f", "x"})
+
+    def test_not_present(self) -> None:
+        assert self.names("y = 1") == frozenset({"y"})
+
+    def test_caching(self) -> None:
+        module = ast.parse("x = 1")
+        assert get_module_names(module) is get_module_names(module)


### PR DESCRIPTION
## Summary

The `utils_timezone` fixer silently skipped files that had no `import datetime`
 statement, even when `django.utils.timezone.utc` or bare `utc` references were present and eligible for rewriting. This affected any codebase using
 `from datetime import ...` style imports alongside the deprecated `django.utils.timezone.utc`.

## Motivation

Fixes #568. The root cause was that `get_import_details()` only scanned for `ast.Import` nodes to set `datetime_module`, ignoring `ast.ImportFrom` nodes entirely. As suggested in the issue, the fix inserts `import datetime as dt` when `dt` is a free name in the module, so existing code patterns like `from datetime import datetime` no longer block the transformation.

**Before:**

```
python # Input — fixer produced no output

from datetime import datetime
from django.utils import timezone

print(datetime.now(tz=timezone.utc))
```

**After:**

``` 
import datetime as dt
from datetime import datetime
from django.utils import timezone

print(datetime.now(tz=dt.timezone.utc))
```

**Changes**

`src/django_upgrade/fixers/utils_timezone.py`

Add `_is_name_used():` walks the full module AST to check whether a name is already bound anywhere, Name nodes, import aliases, function/class definitions, and function arguments
Extend `ImportDetails` with `first_import_node`, `needs_datetime_import`, and `add_import_scheduled` fields
Extend `get_import_details()` to fall back to `dt` as the `datetime` alias when no `import datetime` is found and dt is a free name
Add `add_datetime_import()` token function to insert import datetime as dt before the first import in the file
Add `maybe_add_datetime_import()` generator, mirroring `maybe_rewrite_import()`
Call `maybe_add_datetime_import()` from both `visit_Name` and `visit_Attribute`

`tests/fixers/test_utils_timezone.py`

Update `test_no_datetime_import` from `check_noop` to `check_transformed`
Add `test_no_datetime_import_dt_name_conflict: noop` when dt is already used
Add `test_from_datetime_import_attr:` from `datetime import datetime` + `timezone.utc` → inserts import, rewrites
Add `test_from_datetime_import_name:` from `datetime import datetime` + bare `utc` → inserts import, removes old import, rewrites

**Testing**
20/20 utils_timezone fixer tests pass
981/981 full test suite passes

**Author**
Benjamin Aduo ([@benaduo](https://github.com/benaduo))