### PR TITLE
Extend test_http_headers fixer to cover AsyncClient and AsyncRequestFactory

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ Pending
 
   `PR #646 <https://github.com/adamchainz/django-upgrade/pull/646>`__.
 
+* Extend :ref:`test_http_headers` fixer to cover ``AsyncClient``, ``AsyncRequestFactory``, and ``self.async_client.*()`` calls.
+
+  `PR #633 <https://github.com/adamchainz/django-upgrade/pull/633>`__.
+
 * Extend :ref:`versioned_test_skip_decorators` fixer to also remove the entire decorated function or class when the skip condition is always true.
   For example, when targeting Django 5.2+, a function decorated with ``@pytest.mark.skipif(django.VERSION >= (5, 2), ...)`` will be removed.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ Pending
 
 * Extend :ref:`test_http_headers` fixer to cover ``AsyncClient``, ``AsyncRequestFactory``, and ``self.async_client.*()`` calls.
 
-  `PR #633 <https://github.com/adamchainz/django-upgrade/pull/633>`__.
+  Thanks to Benjamin Aduo in `PR #633 <https://github.com/adamchainz/django-upgrade/pull/633>`__.
 
 * Extend :ref:`versioned_test_skip_decorators` fixer to also remove the entire decorated function or class when the skip condition is always true.
   For example, when targeting Django 5.2+, a function decorated with ``@pytest.mark.skipif(django.VERSION >= (5, 2), ...)`` will be removed.

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -395,6 +395,8 @@ It then uses ``**`` to extend that with any values in the current module:
     +    },
     +}
 
+.. _test_http_headers:
+
 Test client HTTP headers
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -402,9 +402,9 @@ Test client HTTP headers
 
 Transforms HTTP headers from the old WSGI kwarg format to use the new ``headers`` dictionary, for:
 
-* ``Client`` method like ``self.client.get()``
-* ``Client`` instantiation
-* ``RequestFactory`` instantiation
+* ``Client`` and ``AsyncClient`` method calls like ``self.client.get()`` / ``self.async_client.get()``
+* ``Client`` and ``AsyncClient`` instantiation
+* ``RequestFactory`` and ``AsyncRequestFactory`` instantiation
 
 .. code-block:: diff
 

--- a/src/django_upgrade/fixers/test_http_headers.py
+++ b/src/django_upgrade/fixers/test_http_headers.py
@@ -1,6 +1,6 @@
 """
 Transforms HTTP headers from WSGI kwarg format to new 'headers' dictionary, for
-test Client and RequestFactory:
+test Client, AsyncClient, RequestFactory, and AsyncRequestFactory:
 https://docs.djangoproject.com/en/4.2/releases/4.2/#tests
 """
 
@@ -44,10 +44,15 @@ def visit_Call(
     parents: tuple[ast.AST, ...],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Name)
-        and node.func.id in ("Client", "RequestFactory")
-        and node.func.id in state.from_imports["django.test"]
-    ) or looks_like_test_client_call(node, "client"):
+        (
+            isinstance(node.func, ast.Name)
+            and node.func.id
+            in ("AsyncClient", "AsyncRequestFactory", "Client", "RequestFactory")
+            and node.func.id in state.from_imports["django.test"]
+        )
+        or looks_like_test_client_call(node, "client")
+        or looks_like_test_client_call(node, "async_client")
+    ):
         has_http_kwarg = False
         headers_keyword = None
         for keyword in node.keywords:

--- a/tests/fixers/test_test_http_headers.py
+++ b/tests/fixers/test_test_http_headers.py
@@ -413,3 +413,73 @@ def test_client_expression_multiline():
         """,
         filename="tests.py",
     )
+
+
+def test_async_client_instantiation():
+    check_transformed(
+        """\
+        from django.test import AsyncClient
+        AsyncClient(HTTP_HOST="example.com")
+        """,
+        """\
+        from django.test import AsyncClient
+        AsyncClient(headers={"host": "example.com"})
+        """,
+        filename="tests.py",
+    )
+
+
+def test_async_request_factory_instantiation():
+    check_transformed(
+        """\
+        from django.test import AsyncRequestFactory
+        AsyncRequestFactory(HTTP_ACCEPT="application/json")
+        """,
+        """\
+        from django.test import AsyncRequestFactory
+        AsyncRequestFactory(headers={"accept": "application/json"})
+        """,
+        filename="tests.py",
+    )
+
+
+def test_async_client_call():
+    check_transformed(
+        """\
+        self.async_client.get("/", HTTP_HOST="example.com")
+        """,
+        """\
+        self.async_client.get("/", headers={"host": "example.com"})
+        """,
+        filename="tests.py",
+    )
+
+
+def test_async_client_call_multiple_headers():
+    check_transformed(
+        """\
+        self.async_client.get("/", HTTP_HOST="example.com", HTTP_ACCEPT="text/plain")
+        """,
+        """\
+        self.async_client.get("/", headers={"host": "example.com", "accept": "text/plain"})
+        """,
+        filename="tests.py",
+    )
+
+
+def test_async_client_call_multiline():
+    check_transformed(
+        """\
+        response = self.async_client.get(
+            "/",
+            HTTP_HOST="example.com",
+        )
+        """,
+        """\
+        response = self.async_client.get(
+            "/",
+            headers={"host": "example.com"}
+        )
+        """,
+        filename="tests.py",
+    )

--- a/tests/fixers/test_test_http_headers.py
+++ b/tests/fixers/test_test_http_headers.py
@@ -28,6 +28,26 @@ def test_instantiation_custom_client_class():
     )
 
 
+def test_instantiation_async_client_custom_class():
+    check_noop(
+        """
+        from example.test import AsyncClient
+        AsyncClient(HTTP_HOST="example.com")
+        """,
+        filename="tests.py",
+    )
+
+
+def test_instantiation_async_request_factory_custom_class():
+    check_noop(
+        """
+        from example.test import AsyncRequestFactory
+        AsyncRequestFactory(HTTP_HOST="example.com")
+        """,
+        filename="tests.py",
+    )
+
+
 def test_instantiation_unpacked_kwargs():
     check_noop(
         """
@@ -60,6 +80,24 @@ def test_client_call_unpacked_kwargs():
     check_noop(
         """
         self.client.get("/", HTTP_ACCEPT="text/plain", **maybe_has_headers)
+        """,
+        filename="tests.py",
+    )
+
+
+def test_async_client_call_non_http_kwarg():
+    check_noop(
+        """
+        self.async_client.get("/", SCRIPT_NAME="/app/"),
+        """,
+        filename="tests.py",
+    )
+
+
+def test_async_client_call_unpacked_kwargs():
+    check_noop(
+        """
+        self.async_client.get("/", HTTP_ACCEPT="text/plain", **maybe_has_headers)
         """,
         filename="tests.py",
     )

--- a/tests/fixers/test_test_http_headers.py
+++ b/tests/fixers/test_test_http_headers.py
@@ -79,6 +79,20 @@ def test_instantiation_request_factory():
     )
 
 
+def test_instantiation_async_request_factory():
+    check_transformed(
+        """\
+        from django.test import AsyncRequestFactory
+        AsyncRequestFactory(HTTP_ACCEPT="application/json")
+        """,
+        """\
+        from django.test import AsyncRequestFactory
+        AsyncRequestFactory(headers={"accept": "application/json"})
+        """,
+        filename="tests.py",
+    )
+
+
 def test_instantiation():
     check_transformed(
         """\
@@ -88,6 +102,20 @@ def test_instantiation():
         """\
         from django.test import Client
         Client(headers={"host": "example.com"})
+        """,
+        filename="tests.py",
+    )
+
+
+def test_instantiation_async_client():
+    check_transformed(
+        """\
+        from django.test import AsyncClient
+        AsyncClient(HTTP_HOST="example.com")
+        """,
+        """\
+        from django.test import AsyncClient
+        AsyncClient(headers={"host": "example.com"})
         """,
         filename="tests.py",
     )
@@ -266,6 +294,18 @@ def test_client_call():
     )
 
 
+def test_async_client_call():
+    check_transformed(
+        """\
+        self.async_client.get("/", HTTP_HOST="example.com")
+        """,
+        """\
+        self.async_client.get("/", headers={"host": "example.com"})
+        """,
+        filename="tests.py",
+    )
+
+
 def test_client_call_multiple():
     check_transformed(
         """\
@@ -273,6 +313,18 @@ def test_client_call_multiple():
         """,
         """\
         self.client.get("/", headers={"host": "example.com", "accept": "text/plain"})
+        """,
+        filename="tests.py",
+    )
+
+
+def test_async_client_call_multiple():
+    check_transformed(
+        """\
+        self.async_client.get("/", HTTP_HOST="example.com", HTTP_ACCEPT="text/plain")
+        """,
+        """\
+        self.async_client.get("/", headers={"host": "example.com", "accept": "text/plain"})
         """,
         filename="tests.py",
     )
@@ -327,6 +379,24 @@ def test_client_call_multiline():
         response = self.client.get(
             "/",
             {"q": "abc"},
+            headers={"host": "example.com"}
+        )
+        """,
+        filename="tests.py",
+    )
+
+
+def test_async_client_call_multiline():
+    check_transformed(
+        """\
+        response = self.async_client.get(
+            "/",
+            HTTP_HOST="example.com",
+        )
+        """,
+        """\
+        response = self.async_client.get(
+            "/",
             headers={"host": "example.com"}
         )
         """,
@@ -410,76 +480,6 @@ def test_client_expression_multiline():
         self.client.get("/", headers={"host": (
             name + tld
         )})
-        """,
-        filename="tests.py",
-    )
-
-
-def test_async_client_instantiation():
-    check_transformed(
-        """\
-        from django.test import AsyncClient
-        AsyncClient(HTTP_HOST="example.com")
-        """,
-        """\
-        from django.test import AsyncClient
-        AsyncClient(headers={"host": "example.com"})
-        """,
-        filename="tests.py",
-    )
-
-
-def test_async_request_factory_instantiation():
-    check_transformed(
-        """\
-        from django.test import AsyncRequestFactory
-        AsyncRequestFactory(HTTP_ACCEPT="application/json")
-        """,
-        """\
-        from django.test import AsyncRequestFactory
-        AsyncRequestFactory(headers={"accept": "application/json"})
-        """,
-        filename="tests.py",
-    )
-
-
-def test_async_client_call():
-    check_transformed(
-        """\
-        self.async_client.get("/", HTTP_HOST="example.com")
-        """,
-        """\
-        self.async_client.get("/", headers={"host": "example.com"})
-        """,
-        filename="tests.py",
-    )
-
-
-def test_async_client_call_multiple_headers():
-    check_transformed(
-        """\
-        self.async_client.get("/", HTTP_HOST="example.com", HTTP_ACCEPT="text/plain")
-        """,
-        """\
-        self.async_client.get("/", headers={"host": "example.com", "accept": "text/plain"})
-        """,
-        filename="tests.py",
-    )
-
-
-def test_async_client_call_multiline():
-    check_transformed(
-        """\
-        response = self.async_client.get(
-            "/",
-            HTTP_HOST="example.com",
-        )
-        """,
-        """\
-        response = self.async_client.get(
-            "/",
-            headers={"host": "example.com"}
-        )
         """,
         filename="tests.py",
     )


### PR DESCRIPTION
The fixer previously only handled HTTP_* kwargs for Client, RequestFactory, and self.client.*() calls, silently skipping their async counterparts.

This PR extends the fixer to also rewrite AsyncClient, AsyncRequestFactory, and self.async_client.*() calls to use the headers={} dict format introduced in Django 4.2.

Fixes #323