### PR TITLE
Remove Coverage config for 'if TYPE_CHECKING:'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ scripts.django-upgrade = "django_upgrade.main:main"
 
 [dependency-groups]
 test = [
-  "coverage[toml]",
+  "coverage[toml]>=7.10",
   "pytest",
   "pytest-randomly",
 ]
@@ -137,9 +137,6 @@ run.source = [
 paths.source = [
   "src",
   ".tox/**/site-packages",
-]
-report.exclude_also = [
-  "if TYPE_CHECKING:",
 ]
 report.show_missing = true
 report.skip_covered = true

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ docs = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
 ]
 test = [
-    { name = "coverage", extras = ["toml"] },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.10" },
     { name = "pytest" },
     { name = "pytest-randomly" },
 ]


### PR DESCRIPTION
It's in the default list since Coverage 7.10.0.
