### PR TITLE
Improve def-erasing function

### DIFF
--- a/src/django_upgrade/fixers/versioned_test_skip_decorators.py
+++ b/src/django_upgrade/fixers/versioned_test_skip_decorators.py
@@ -31,7 +31,7 @@ from tokenize_rt import Offset
 
 from django_upgrade.ast import ast_start_offset, is_passing_comparison
 from django_upgrade.data import Fixer, State, TokenFunc
-from django_upgrade.tokens import erase_decorated_def, erase_decorator
+from django_upgrade.tokens import erase_decorator, erase_def
 
 fixer = Fixer(
     __name__,
@@ -127,11 +127,7 @@ def _handle_decorator(
             if always_skipped:
                 yield (
                     ast_start_offset(node.decorator_list[0]),
-                    partial(
-                        erase_decorated_def,
-                        first_decorator=node.decorator_list[0],
-                        node=node,
-                    ),
+                    partial(erase_def, node=node),
                 )
                 break
             else:

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -367,11 +367,10 @@ def erase_decorator(tokens: list[Token], i: int, *, node: ast.Call) -> None:
     del tokens[i : j + 1]
 
 
-def erase_decorated_def(
+def erase_def(
     tokens: list[Token],
     i: int,
     *,
-    first_decorator: ast.expr,
     node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef,
 ) -> None:
     """
@@ -379,7 +378,6 @@ def erase_decorated_def(
     decorators.
     """
     _, j = find_node(tokens, i, node=node)
-    i, _ = find_node(tokens, i, node=first_decorator)
     i = reverse_find(tokens, i, name=OP, src="@")
     i = reverse_consume(tokens, i, name=INDENT)
     i = reverse_consume(tokens, i, name=UNIMPORTANT_WS)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -5,7 +5,12 @@ import ast
 import pytest
 from tokenize_rt import Token, src_to_tokens, tokens_to_src
 
-from django_upgrade.tokens import str_repr_matching, update_import_names
+from django_upgrade.tokens import (
+    erase_def,
+    find_first_token,
+    str_repr_matching,
+    update_import_names,
+)
 
 
 @pytest.mark.parametrize(
@@ -25,6 +30,49 @@ def test_str_repr_matching(text, match_quotes, expected):
 
 def tokenize_and_parse(source: str) -> tuple[list[Token], ast.Module]:
     return src_to_tokens(source), ast.parse(source)
+
+
+class TestEraseDef:
+    def check_transformed(
+        self, *, before: str, after: str, node_index: int = 0
+    ) -> None:
+        tokens, mod = tokenize_and_parse(before)
+        node = mod.body[node_index]
+        assert isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef))
+        i = find_first_token(tokens, 0, node=node.decorator_list[0])
+        erase_def(tokens, i, node=node)
+        assert tokens_to_src(tokens) == after
+
+    def test_function(self):
+        self.check_transformed(
+            before="@dec\ndef foo():\n    pass\n",
+            after="",
+        )
+
+    def test_two_decorators(self):
+        self.check_transformed(
+            before="@dec1\n@dec2\ndef foo():\n    pass\n",
+            after="",
+        )
+
+    def test_preceding_statement(self):
+        self.check_transformed(
+            before="x = 1\n\n@dec\ndef foo():\n    pass\n",
+            after="x = 1\n",
+            node_index=1,
+        )
+
+    def test_async_function(self):
+        self.check_transformed(
+            before="@dec\nasync def foo():\n    pass\n",
+            after="",
+        )
+
+    def test_class(self):
+        self.check_transformed(
+            before="@dec\nclass Foo:\n    pass\n",
+            after="",
+        )
 
 
 class TestUpdateImportNames:


### PR DESCRIPTION
Update erase_decorated_def, introduced in ##648, by renaming it to erase_def, removing the first decorator argument, and testing it independently.