### PR TITLE
Add Django 6.1+ compatibility_imports fixer entries for bit aggregates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,16 +9,20 @@ Pending
 
   `PR #646 <https://github.com/adamchainz/django-upgrade/pull/646>`__.
 
-* Extend :ref:`test_http_headers` fixer to cover ``AsyncClient``, ``AsyncRequestFactory``, and ``self.async_client.*()`` calls.
+* Add Django 6.1+ ``compatibility_imports`` :ref:`fixer entries <postgres_bit_aggregates>` to move ``BitAnd``, ``BitOr``, and ``BitXor`` imports from ``django.contrib.postgres.aggregates`` to ``django.db.models``.
+
+  `PR #658 <https://github.com/adamchainz/django-upgrade/pull/658>`__.
+
+* Extend :ref:`test_http_headers <test_http_headers>` fixer to cover ``AsyncClient``, ``AsyncRequestFactory``, and ``self.async_client.*()`` calls.
 
   Thanks to Benjamin Aduo in `PR #633 <https://github.com/adamchainz/django-upgrade/pull/633>`__.
 
-* Extend :ref:`versioned_test_skip_decorators` fixer to also remove the entire decorated function or class when the skip condition is always true.
+* Extend :ref:`versioned_test_skip_decorators <versioned_test_skip_decorators>` fixer to also remove the entire decorated function or class when the skip condition is always true.
   For example, when targeting Django 5.2+, a function decorated with ``@pytest.mark.skipif(django.VERSION >= (5, 2), ...)`` will be removed.
 
   `PR #648 <https://github.com/adamchainz/django-upgrade/pull/648>`__.
 
-* Extend :ref:`versioned_test_skip_decorators` fixer to support async function definitions.
+* Extend :ref:`versioned_test_skip_decorators <versioned_test_skip_decorators>` fixer to support async function definitions.
 
   `PR #649 <https://github.com/adamchainz/django-upgrade/pull/649>`__.
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -132,7 +132,19 @@ Django 6.1
 
 `Release Notes <https://docs.djangoproject.com/en/6.1/releases/6.1/>`__
 
-(No fixers yet.)
+.. _postgres_bit_aggregates:
+
+``BitAnd``, ``BitOr``, and ``BitXor`` aggregate move
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``compatibility_imports``
+
+Rewrites imports of ``BitAnd``, ``BitOr``, and ``BitXor`` from ``django.contrib.postgres.aggregates`` to the new all-database versions in ``django.db.models``, per `this change <https://docs.djangoproject.com/en/6.1/releases/6.1/#:~:text=The%20BitAnd%2C%20BitOr%2C%20and%20BitXor%20classes>`__.
+
+.. code-block:: diff
+
+    -from django.contrib.postgres.aggregates import BitAnd, BitOr, BitXor
+    +from django.db.models import BitAnd, BitOr, BitXor
 
 Django 6.0
 ----------

--- a/src/django_upgrade/fixers/compatibility_imports.py
+++ b/src/django_upgrade/fixers/compatibility_imports.py
@@ -103,6 +103,18 @@ REPLACEMENTS_EXACT = {
             "TRANSLATOR_COMMENT_MARK": "django.utils.translation.template"
         }
     },
+    (6, 1): {
+        "django.contrib.postgres.aggregates": {
+            "BitAnd": "django.db.models",
+            "BitOr": "django.db.models",
+            "BitXor": "django.db.models",
+        },
+        "django.contrib.postgres.aggregates.general": {
+            "BitAnd": "django.db.models",
+            "BitOr": "django.db.models",
+            "BitXor": "django.db.models",
+        },
+    },
 }
 REPLACEMENTS_EXCEPT_MIGRATIONS = {
     (3, 1): {

--- a/tests/fixers/test_compatibility_imports.py
+++ b/tests/fixers/test_compatibility_imports.py
@@ -414,3 +414,98 @@ def test_urlresolvers_transformed():
         """,
         Settings(target_version=(1, 10)),
     )
+
+
+class TestPostgresBitAggregates:
+    settings = Settings(target_version=(6, 1))
+
+    def test_unmatched_import(self):
+        check_noop(
+            """\
+            from example import BitAnd
+            """,
+            self.settings,
+        )
+
+    def test_no_matching_name(self):
+        check_noop(
+            """\
+            from django.contrib.postgres.aggregates import ArrayAgg
+            """,
+            self.settings,
+        )
+
+    def test_old_target_version(self):
+        check_noop(
+            """\
+            from django.contrib.postgres.aggregates import BitAnd
+            """,
+            Settings(target_version=(6, 0)),
+        )
+
+    def test_bitand(self):
+        check_transformed(
+            """\
+            from django.contrib.postgres.aggregates import BitAnd
+            """,
+            """\
+            from django.db.models import BitAnd
+            """,
+            self.settings,
+        )
+
+    def test_bitor(self):
+        check_transformed(
+            """\
+            from django.contrib.postgres.aggregates import BitOr
+            """,
+            """\
+            from django.db.models import BitOr
+            """,
+            self.settings,
+        )
+
+    def test_bitxor(self):
+        check_transformed(
+            """\
+            from django.contrib.postgres.aggregates import BitXor
+            """,
+            """\
+            from django.db.models import BitXor
+            """,
+            self.settings,
+        )
+
+    def test_all_three(self):
+        check_transformed(
+            """\
+            from django.contrib.postgres.aggregates import BitAnd, BitOr, BitXor
+            """,
+            """\
+            from django.db.models import BitAnd, BitOr, BitXor
+            """,
+            self.settings,
+        )
+
+    def test_mixed_with_other_imports(self):
+        check_transformed(
+            """\
+            from django.contrib.postgres.aggregates import ArrayAgg, BitAnd, BitOr
+            """,
+            """\
+            from django.db.models import BitAnd, BitOr
+            from django.contrib.postgres.aggregates import ArrayAgg
+            """,
+            self.settings,
+        )
+
+    def test_general_submodule(self):
+        check_transformed(
+            """\
+            from django.contrib.postgres.aggregates.general import BitAnd
+            """,
+            """\
+            from django.db.models import BitAnd
+            """,
+            self.settings,
+        )


### PR DESCRIPTION
Fixes #650.