### PR TITLE
Add Django 6.1 fixer for `AdminEmailHandler` `email_backend` argument rename.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,11 +9,15 @@ Pending
 
   `PR #646 <https://github.com/adamchainz/django-upgrade/pull/646>`__.
 
+* Add Django 6.1+ :ref:`settings_logging_admin_email_handler <settings_logging_admin_email_handler>` fixer to rename the ``email_backend`` argument of ``AdminEmailHandler`` in the ``LOGGING`` setting to ``using``.
+
+  `PR #662 <https://github.com/adamchainz/django-upgrade/pull/662>`__.
+
 * Add Django 6.1+ ``compatibility_imports`` :ref:`fixer entries <postgres_bit_aggregates>` to move ``BitAnd``, ``BitOr``, and ``BitXor`` imports from ``django.contrib.postgres.aggregates`` to ``django.db.models``.
 
   `PR #658 <https://github.com/adamchainz/django-upgrade/pull/658>`__.
 
-* Add Django 6.1+ :ref:`transaction_savepoint` fixer to rename ``django.db.transaction``\’s ``savepoint`` to ``savepoint_create``.
+* Add Django 6.1+ :ref:`transaction_savepoint <transaction_savepoint>` fixer to rename ``django.db.transaction``\’s ``savepoint`` to ``savepoint_create``.
 
   `PR #660 <https://github.com/adamchainz/django-upgrade/pull/660>`__.
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -132,6 +132,30 @@ Django 6.1
 
 `Release Notes <https://docs.djangoproject.com/en/6.1/releases/6.1/>`__
 
+.. _settings_logging_admin_email_handler:
+
+``AdminEmailHandler`` ``email_backend`` argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``settings_logging_admin_email_handler``
+
+Renames the deprecated ``email_backend`` argument of ``AdminEmailHandler`` in the ``LOGGING`` setting to ``using``, per `this change <https://docs.djangoproject.com/en/6.1/releases/6.1/#:~:text=email_backend%20argument>`__.
+
+Settings files are heuristically detected as modules with the whole word ``settings`` somewhere in their path.
+For example ``myproject/settings.py`` or ``myproject/settings/production.py``.
+
+.. code-block:: diff
+
+    LOGGING = {
+        "handlers": {
+            "mail_admins": {
+                "class": "django.utils.log.AdminEmailHandler",
+   -            "email_backend": "myapp.backends.EmailBackend",
+   +            "using": "myapp.backends.EmailBackend",
+            },
+        },
+    }
+
 .. _postgres_bit_aggregates:
 
 ``BitAnd``, ``BitOr``, and ``BitXor`` aggregate move

--- a/src/django_upgrade/fixers/settings_logging_admin_email_handler.py
+++ b/src/django_upgrade/fixers/settings_logging_admin_email_handler.py
@@ -1,0 +1,90 @@
+"""
+Rename 'email_backend' to 'using' in AdminEmailHandler LOGGING config:
+https://docs.djangoproject.com/en/6.1/releases/6.1/#:~:text=email_backend%20argument
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable
+
+from tokenize_rt import Offset, Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.tokens import str_repr_matching
+
+fixer = Fixer(
+    __name__,
+    min_version=(6, 1),
+    condition=lambda state: state.looks_like_settings_file,
+)
+
+
+@fixer.register(ast.Assign)
+def visit_Assign(
+    state: State,
+    node: ast.Assign,
+    parents: tuple[ast.AST, ...],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "LOGGING"
+        and isinstance(node.value, ast.Dict)
+        and (
+            isinstance(parents[-1], ast.Module)
+            or (
+                isinstance(parents[-1], ast.ClassDef)
+                and len(parents[-1].body) > 1
+                and isinstance(parents[-2], ast.Module)
+            )
+        )
+    ):
+        for key_node in _find_handler_email_backend_keys(node.value):
+            yield ast_start_offset(key_node), rename_email_backend_key
+
+
+def _find_handler_email_backend_keys(
+    logging_dict: ast.Dict,
+) -> Iterable[ast.Constant]:
+    """
+    Follow LOGGING["handlers"][*] and yield the 'email_backend' key node for
+    each handler dict that configures AdminEmailHandler with that argument.
+    """
+    handlers_dict = _get_dict_value(logging_dict, "handlers")
+    if handlers_dict is None:
+        return
+    for handler_value in handlers_dict.values:
+        if not isinstance(handler_value, ast.Dict):
+            continue
+        if not any(
+            (
+                isinstance(k, ast.Constant)
+                and k.value == "class"
+                and isinstance(v, ast.Constant)
+                and v.value == "django.utils.log.AdminEmailHandler"
+            )
+            for k, v in zip(handler_value.keys, handler_value.values)
+        ):
+            continue
+        for hkey in handler_value.keys:
+            if isinstance(hkey, ast.Constant) and hkey.value == "email_backend":
+                yield hkey
+
+
+def _get_dict_value(node: ast.Dict, key: str) -> ast.Dict | None:
+    """
+    Return the value for a string-literal key in a dict literal, if it is
+    itself a dict literal.
+    """
+    for k, v in zip(node.keys, node.values):
+        if isinstance(k, ast.Constant) and k.value == key and isinstance(v, ast.Dict):
+            return v
+    return None
+
+
+def rename_email_backend_key(tokens: list[Token], i: int) -> None:
+    tokens[i] = tokens[i]._replace(
+        src=str_repr_matching("using", match_quotes=tokens[i].src)
+    )

--- a/tests/fixers/test_settings_logging_admin_email_handler.py
+++ b/tests/fixers/test_settings_logging_admin_email_handler.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from functools import partial
+
+from django_upgrade.data import Settings
+from tests.fixers import tools
+
+settings = Settings(target_version=(6, 1))
+check_noop = partial(tools.check_noop, settings=settings)
+check_transformed = partial(tools.check_transformed, settings=settings)
+
+
+def test_not_settings_file():
+    check_noop(
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "email_backend": "myapp.backends.EmailBackend",
+                },
+            },
+        }
+        """,
+    )
+
+
+def test_old_version():
+    check_noop(
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "email_backend": "myapp.backends.EmailBackend",
+                },
+            },
+        }
+        """,
+        settings=Settings(target_version=(6, 0)),
+        filename="settings.py",
+    )
+
+
+def test_two_targets():
+    check_noop(
+        """\
+        LOGGING = OTHER = {
+            "handlers": {
+                "mail_admins": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "email_backend": "myapp.backends.EmailBackend",
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_not_logging():
+    check_noop(
+        """\
+        OTHER = {
+            "handlers": {
+                "mail_admins": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "email_backend": "myapp.backends.EmailBackend",
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_not_dict():
+    check_noop(
+        """\
+        LOGGING = get_logging_config()
+        """,
+        filename="settings.py",
+    )
+
+
+def test_email_backend_not_in_handlers():
+    check_noop(
+        """\
+        LOGGING = {
+            "filters": {
+                "special": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "email_backend": "myapp.backends.EmailBackend",
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_handler_value_not_dict():
+    check_noop(
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins": get_handler(),
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_no_admin_email_handler():
+    check_noop(
+        """\
+        LOGGING = {
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "email_backend": "myapp.backends.EmailBackend",
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_no_email_backend():
+    check_noop(
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_already_using():
+    check_noop(
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "using": "admin-logging",
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_success():
+    check_transformed(
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "email_backend": "myapp.backends.EmailBackend",
+                },
+            },
+        }
+        """,
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "using": "myapp.backends.EmailBackend",
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_success_single_quotes():
+    check_transformed(
+        """\
+        LOGGING = {
+            'handlers': {
+                'mail_admins': {
+                    'class': 'django.utils.log.AdminEmailHandler',
+                    'email_backend': 'myapp.backends.EmailBackend',
+                },
+            },
+        }
+        """,
+        """\
+        LOGGING = {
+            'handlers': {
+                'mail_admins': {
+                    'class': 'django.utils.log.AdminEmailHandler',
+                    'using': 'myapp.backends.EmailBackend',
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_success_multiple_handlers():
+    check_transformed(
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins_1": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "email_backend": "myapp.backends.Email1",
+                },
+                "mail_admins_2": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "email_backend": "myapp.backends.Email2",
+                },
+            },
+        }
+        """,
+        """\
+        LOGGING = {
+            "handlers": {
+                "mail_admins_1": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "using": "myapp.backends.Email1",
+                },
+                "mail_admins_2": {
+                    "class": "django.utils.log.AdminEmailHandler",
+                    "using": "myapp.backends.Email2",
+                },
+            },
+        }
+        """,
+        filename="settings.py",
+    )
+
+
+def test_success_class_settings():
+    check_transformed(
+        """\
+        class Settings:
+            LOGGING = {
+                "handlers": {
+                    "mail_admins": {
+                        "class": "django.utils.log.AdminEmailHandler",
+                        "email_backend": "myapp.backends.EmailBackend",
+                    },
+                },
+            }
+            OTHER = True
+        """,
+        """\
+        class Settings:
+            LOGGING = {
+                "handlers": {
+                    "mail_admins": {
+                        "class": "django.utils.log.AdminEmailHandler",
+                        "using": "myapp.backends.EmailBackend",
+                    },
+                },
+            }
+            OTHER = True
+        """,
+        filename="settings.py",
+    )


### PR DESCRIPTION
Fixes #652.