### PR TITLE
Fix utils_timezone import insertion edge cases

### DIFF
--- a/src/django_upgrade/ast.py
+++ b/src/django_upgrade/ast.py
@@ -24,12 +24,24 @@ def get_module_names(module: ast.Module) -> frozenset[str]:
     for node in ast.walk(module):
         if isinstance(node, ast.Name):
             names.add(node.id)
-        elif isinstance(node, ast.alias):
-            names.add(node.asname if node.asname is not None else node.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname is not None:
+                    names.add(alias.asname)
+                else:
+                    names.add(alias.name.partition(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                names.add(alias.asname if alias.asname is not None else alias.name)
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             names.add(node.name)
         elif isinstance(node, ast.arg):
             names.add(node.arg)
+        elif isinstance(node, (ast.ExceptHandler, ast.MatchAs, ast.MatchStar)):
+            if node.name is not None:
+                names.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest is not None:
+            names.add(node.rest)
 
     result = frozenset(names)
     _module_names[module] = result

--- a/src/django_upgrade/fixers/utils_timezone.py
+++ b/src/django_upgrade/fixers/utils_timezone.py
@@ -113,6 +113,9 @@ def get_import_details(state: State, module: ast.AST) -> ImportDetails:
         if not isinstance(node, (ast.Import, ast.ImportFrom)):
             break
 
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            continue
+
         if details.first_import_node is None:
             details.first_import_node = node
 
@@ -133,7 +136,11 @@ def get_import_details(state: State, module: ast.AST) -> ImportDetails:
         ):
             details.old_utc_import = node
 
-    if details.datetime_module is None and "dt" not in get_module_names(module):
+    if (
+        details.datetime_module is None
+        and details.first_import_node is not None
+        and "dt" not in get_module_names(module)
+    ):
         details.datetime_module = "dt"
         details.needs_datetime_import = True
 

--- a/tests/fixers/test_utils_timezone.py
+++ b/tests/fixers/test_utils_timezone.py
@@ -70,6 +70,46 @@ def test_no_datetime_import_dt_name_conflict():
     )
 
 
+def test_no_datetime_import_dt_dotted_import_conflict():
+    check_noop(
+        """\
+        import dt.foo
+        from django.utils import timezone
+
+        do_a_thing(timezone.utc)
+        """,
+    )
+
+
+def test_no_datetime_import_dt_except_handler_conflict():
+    check_noop(
+        """\
+        from django.utils import timezone
+
+        try:
+            pass
+        except Exception as dt:
+            pass
+
+        do_a_thing(timezone.utc)
+        """,
+    )
+
+
+def test_no_datetime_import_dt_pattern_conflict():
+    check_noop(
+        """\
+        from django.utils import timezone
+
+        match value:
+            case dt:
+                pass
+
+        do_a_thing(timezone.utc)
+        """,
+    )
+
+
 def test_basic():
     check_transformed(
         """\
@@ -378,5 +418,23 @@ def test_from_datetime_import_attr():
         from django.utils import timezone
 
         do_a_thing(datetime.now(tz=dt.timezone.utc))
+        """,
+    )
+
+
+def test_no_datetime_import_future_import():
+    check_transformed(
+        """\
+        from __future__ import annotations
+        from django.utils import timezone
+
+        do_a_thing(timezone.utc)
+        """,
+        """\
+        from __future__ import annotations
+        import datetime as dt
+        from django.utils import timezone
+
+        do_a_thing(dt.timezone.utc)
         """,
     )

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -63,6 +63,11 @@ class TestGetModuleNames:
     def test_pattern(self, src: str, expected: frozenset[str]) -> None:
         assert self.names(src) == expected
 
+    def test_pattern_wildcard(self) -> None:
+        assert self.names("match value:\n    case _:\n        pass") == frozenset(
+            {"value"}
+        )
+
     def test_except_handler(self) -> None:
         assert self.names(
             "try:\n    pass\nexcept Exception as x:\n    pass"

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -31,8 +31,11 @@ class TestGetModuleNames:
             "from m import y as x",
         ),
     )
-    def test_alias(self, src: str) -> None:
+    def test_import_alias(self, src: str) -> None:
         assert self.names(src) == frozenset({"x"})
+
+    def test_dotted_import(self) -> None:
+        assert self.names("import x.y") == frozenset({"x"})
 
     def test_function_def(self) -> None:
         assert self.names("def x(): pass") == frozenset({"x"})
@@ -46,8 +49,24 @@ class TestGetModuleNames:
     def test_arg(self) -> None:
         assert self.names("def f(x): pass") == frozenset({"f", "x"})
 
-    def test_not_present(self) -> None:
+    def test_assignment(self) -> None:
         assert self.names("y = 1") == frozenset({"y"})
+
+    @pytest.mark.parametrize(
+        ("src", "expected"),
+        (
+            ("match value:\n    case x:\n        pass", frozenset({"value", "x"})),
+            ("match value:\n    case [*x]:\n        pass", frozenset({"value", "x"})),
+            ("match value:\n    case {**x}:\n        pass", frozenset({"value", "x"})),
+        ),
+    )
+    def test_pattern(self, src: str, expected: frozenset[str]) -> None:
+        assert self.names(src) == expected
+
+    def test_except_handler(self) -> None:
+        assert self.names(
+            "try:\n    pass\nexcept Exception as x:\n    pass"
+        ) == frozenset({"Exception", "x"})
 
     def test_caching(self) -> None:
         module = ast.parse("x = 1")


### PR DESCRIPTION
Keep generated datetime imports after future imports, and avoid inserting import datetime as dt when dotted imports, exception handlers, or pattern captures already bind dt.