### PR TITLE
Add Django 7.0 fixer for USE_BLANK_CHOICE_DASH setting removal.

### DIFF
--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -220,6 +220,27 @@ Renames the deprecated ``savepoint`` function in ``django.db.transaction`` to ``
     +from django.db import transaction
     +transaction.savepoint_create("name")
 
+Django 7.0
+----------
+
+`Release Notes <https://docs.djangoproject.com/en/7.0/releases/7.0/>`__
+
+.. _settings_use_blank_choice_dash:
+
+``USE_BLANK_CHOICE_DASH`` setting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Name:** ``settings_use_blank_choice_dash``
+
+Removes the transitional setting ``USE_BLANK_CHOICE_DASH`` from settings files, as it no longer has any effect.
+
+Settings files are heuristically detected as modules with the whole word "settings" somewhere in their path.
+For example ``myproject/settings.py`` or ``myproject/settings/production.py``.
+
+.. code-block:: diff
+
+    -USE_BLANK_CHOICE_DASH = True
+
 Django 6.0
 ----------
 

--- a/src/django_upgrade/fixers/settings_use_blank_choice_dash.py
+++ b/src/django_upgrade/fixers/settings_use_blank_choice_dash.py
@@ -1,0 +1,46 @@
+"""
+The USE_BLANK_CHOICE_DASH setting was removed:
+https://docs.djangoproject.com/en/dev/releases/7.0/#features-removed-in-7-0
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable
+from functools import partial
+
+from tokenize_rt import Offset
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer, State, TokenFunc
+from django_upgrade.tokens import erase_node
+
+fixer = Fixer(
+    __name__,
+    min_version=(7, 0),
+    condition=lambda state: state.looks_like_settings_file,
+)
+
+
+@fixer.register(ast.Assign)
+def visit_Assign(
+    state: State,
+    node: ast.Assign,
+    parents: tuple[ast.AST, ...],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "USE_BLANK_CHOICE_DASH"
+        and isinstance(node.value, ast.Constant)
+        and node.value.value is True
+        and (
+            isinstance(parents[-1], ast.Module)
+            or (
+                isinstance(parents[-1], ast.ClassDef)
+                and len(parents[-1].body) > 1
+                and isinstance(parents[-2], ast.Module)
+            )
+        )
+    ):
+        yield ast_start_offset(node), partial(erase_node, node=node)

--- a/tests/fixers/test_settings_use_blank_choice_dash.py
+++ b/tests/fixers/test_settings_use_blank_choice_dash.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from functools import partial
+
+from django_upgrade.data import Settings
+from tests.fixers import tools
+
+settings = Settings(target_version=(7, 0))
+check_noop = partial(tools.check_noop, settings=settings)
+check_transformed = partial(tools.check_transformed, settings=settings)
+
+
+def test_not_settings_file():
+    check_noop(
+        """\
+        USE_BLANK_CHOICE_DASH = True
+        """,
+    )
+
+
+def test_false():
+    check_noop(
+        """\
+        USE_BLANK_CHOICE_DASH = False
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_dynamic():
+    check_noop(
+        """\
+        import os
+        USE_BLANK_CHOICE_DASH = os.environ["USE_BLANK_CHOICE_DASH"]
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_ignore_conditional():
+    check_noop(
+        """\
+        if something:
+            USE_BLANK_CHOICE_DASH = True
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_success():
+    check_transformed(
+        """\
+        USE_BLANK_CHOICE_DASH = True
+        """,
+        "",
+        filename="myapp/settings.py",
+    )
+
+
+def test_success_comment():
+    check_transformed(
+        """\
+        USE_BLANK_CHOICE_DASH = True  # blank choice compat
+        """,
+        "",
+        filename="myapp/settings.py",
+    )
+
+
+def test_success_settings_subfolder():
+    check_transformed(
+        """\
+        USE_BLANK_CHOICE_DASH = True
+        """,
+        "",
+        filename="myapp/settings/prod.py",
+    )
+
+
+def test_success_function_call_multiline():
+    check_transformed(
+        """\
+        USE_BLANK_CHOICE_DASH = \
+            True
+        """,
+        "",
+        filename="myapp/settings.py",
+    )
+
+
+def test_success_with_other_lines():
+    check_transformed(
+        """\
+        import os
+        USE_BLANK_CHOICE_DASH = True
+        ANOTHER_SETTING = True
+        """,
+        """\
+        import os
+        ANOTHER_SETTING = True
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_not_settings_file():
+    check_noop(
+        """\
+        class Settings:
+            ADMINS = []
+            USE_BLANK_CHOICE_DASH = True
+        """,
+    )
+
+
+def test_class_false():
+    check_noop(
+        """\
+        class Settings:
+            ADMINS = []
+            USE_BLANK_CHOICE_DASH = False
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_dynamic():
+    check_noop(
+        """\
+        import os
+        class Settings:
+            ADMINS = []
+            USE_BLANK_CHOICE_DASH = os.environ["USE_BLANK_CHOICE_DASH"]
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_ignore_conditional():
+    check_noop(
+        """\
+        class Settings:
+            ADMINS = []
+            if something:
+                USE_BLANK_CHOICE_DASH = True
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_only_assignment():
+    check_noop(
+        """\
+        class Settings:
+            USE_BLANK_CHOICE_DASH = True
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_success():
+    check_transformed(
+        """\
+        class Settings:
+            ADMINS = []
+            USE_BLANK_CHOICE_DASH = True
+        """,
+        """\
+        class Settings:
+            ADMINS = []
+        """,
+        filename="myapp/settings.py",
+    )
+
+
+def test_class_success_with_inheritance():
+    check_transformed(
+        """\
+        class BaseSettings:
+            ADMINS = []
+            USE_BLANK_CHOICE_DASH = True
+
+        class ProdSettings(BaseSettings):
+            ADMINS = []
+            USE_BLANK_CHOICE_DASH = True
+        """,
+        """\
+        class BaseSettings:
+            ADMINS = []
+
+        class ProdSettings(BaseSettings):
+            ADMINS = []
+        """,
+        filename="myapp/settings/base.py",
+    )


### PR DESCRIPTION
Removes the transitional \USE_BLANK_CHOICE_DASH = True\ setting from settings files, as it no longer has any effect since Django 7.0.

Operates on module-level and class-level assignments in heuristically-detected settings files.

Ref: https://docs.djangoproject.com/en/dev/releases/7.0/#features-removed-in-7-0