### PR TITLE
Switch build backend to uv_build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-prune tests
-include CHANGELOG.rst
-include LICENSE
-include pyproject.toml
-include README.rst
-include src/*/py.typed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Switch package build backend from setuptools to `uv_build <https://docs.astral.sh/uv/concepts/build-backend/>`__.
+  This makes builds with uv about nine times faster, since uv runs the backend natively, without creating a build environment or spawning a Python process.
+  Additionally, source distributions no longer include test files, which setuptools previously included incompletely, missing the files needed to actually run them.
+
 1.31.1 (2026-06-26)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
-build-backend = "setuptools.build_meta"
+build-backend = "uv_build"
 requires = [
-  "setuptools>=77",
+  "uv-build>=0.12.1,<0.13",
 ]
 
 [project]


### PR DESCRIPTION
setuptools works fine but the uv build backend is faster and requires less configuration, such as no MANIFEST.in file.

Docs: https://docs.astral.sh/uv/concepts/build-backend/
